### PR TITLE
Added the functionality to fetch the Kubernetes Version, for chaos-ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,44 @@
   numeric value(not-executed:0, running:1, fail:2, pass:3)
 
 - The metrics carry the application_uuid as label (this has to be passed as ENV)
-
 ## Steps to build & deploy: 
 
 ### Local Machine 
 
-- Set the application deployment (assuming a live K8s cluster w/ app) UUID as ENV (APP_UUID)
+#### Pre-requisites:
 
-- Set the ChaosEngine CR name as ENV (CHAOSENGINE) 
-  - For CR spec, see: https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine.yaml
+- A Working Local Kubernetes Cluster (Eg: Minikube or Vagrant)
+  - Set each of these Custom Resource Definition in your Kubernetes Cluster
+  - For ChaosEngine : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine_crd.yaml
+  - For ChaosResult : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosresults_crd.yaml
+  - For ChaosExperiment: https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosexperiment_crd.yaml
+  For information on these Custom Resources, please check this link : https://docs.litmuschaos.io/docs/next/co-components.html
+- Kube-config path of your local Kubernetes Cluster
+- `$GOPATH` set to your working directory
 
-- If the experiments are not executed, apply the ChaosResult CRs manually 
-  - For CR spec, see: https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosresult.yaml
+### Further Steps: 
 
-- Run the exporter container (litmuschaos/chaos-exporter:ci) on host network. It is necessary to mount the kubeconfig
-  & override entrypoint w/ `./exporter -kubeconfig <path>`
+The following steps are required to create sample chaos-related custom resources in order to visualize the metrics gathered by the chaos exporter
 
-- Execute `curl 127.0.0.1:8080/metrics` to view metrics
+- Clone this repo into your $GOPATH/litmuschaos"
+  `git clone https://github.com/litmuschaos/chaos-exporter`
+- Set an APP_UUID in the `~/.bashrc` or the `~/.profile`, add this command to set a default
+- Now, start your Local Cluster, (this guide helps in `minikube` but can be used for other offline clusters as well)
+- Create Kubernetes CR's(Custom Resources) for the litmus operator, link down below:
+- Now, as you have created the CustomResourceDefinition, Now it time to create the CustomResources for these definition above:
+  - For Default ChaosEngine : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine.yaml
+    NOTE THAT THIS CHAOSENGINE COMES WITH A DEFAULT NAME ASSIGNED WITH IT WHICH IS : `engine-nginx`  you would need this afterwards
+  - For Default ChaosResult : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosresult.yaml
+  - For the Default Experiments (Pod Delete Experiment) : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosexperiment.yaml
+- As you have created the ChaosEngine, now again make changes in the `~/.bashrc` or the `~/.profile`, and the add this statement `export CHAOSENGINE=engine-nginx`, if you have changed the ChaosEngine name, then make those changes here as well.
+- Execute the command `source ~/.bashrc` or `source ~/.profile` according to the file you made changes in
+- Now try the command `echo $APP_UUID` and `echo $CHAOSENGINE` , and check the outputs annd verify if they are set according to your preference.
+  - APP_UUID is derived from the app to be added as a metric label for Prometheus Exporter, as same for the ChaosEngine.
+- Run the command `make build` in the root directory.
+- Find your kube-config file for your local cluster.
+  - For minikube it is located in the directory `/home/user_name/.kube/config`, keep this path handy with you
+- After building the file execute this command `sudo ./main -kubeconfig=path_for_the_kubeconfig`
+- Execute `curl 127.0.0.1:8080/metrics | less` to view metrics
 
 ### On Kubernetes Cluster
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,17 +1,17 @@
 /* The chaos exporter collects and exposes the following type of metrics:
 
    Fixed (always captured):
-     - Total number of chaos experiments 
-     - Total number of passed experiments 
+     - Total number of chaos experiments
+     - Total number of passed experiments
      - Total Number of failed experiments
- 
+
    Dynamic (experiment list may vary based on c.engine):
      - States of individual chaos experiments
      - {not-executed:0, running:1, fail:2, pass:3}
        TODO: Improve representaion of test state
 
    Common experiments include:
- 
+
      - pod_failure
      - container_kill
      - container_network_delay
@@ -21,18 +21,20 @@
 package main
 
 import (
-  "os"
-  "time"
-  //"fmt"
-  "flag"
-  "net/http"
-  "strings"
-  "github.com/litmuschaos/chaos-exporter/pkg/util"
-  log "github.com/Sirupsen/logrus"
-  "github.com/prometheus/client_golang/prometheus"
-  "github.com/prometheus/client_golang/prometheus/promhttp"
-  "k8s.io/client-go/tools/clientcmd"
-  "k8s.io/client-go/rest"
+	"os"
+	"time"
+
+	//"fmt"
+	"flag"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/litmuschaos/chaos-exporter/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Declare general variables (cluster ops, error handling, misc)
@@ -43,135 +45,141 @@ var registeredResultMetrics []string
 
 // Declare the fixed chaos metrics. Dynamic (testStatus) metrics are defined in metrics()
 var (
-    experimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "experiment_count",
-        Help:      "Total number of experiments executed by the chaos engine",
-    },
-    []string{"app_uid", "engine_name"},
-    )
+	experimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "experiment_count",
+		Help:      "Total number of experiments executed by the chaos engine",
+	},
+		[]string{"app_uid", "engine_name", "kube_version"},
+	)
 
-    passedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "passed_experiments",
-        Help:      "Total number of passed experiments",
-    },
-    []string{"app_uid", "engine_name"},
-    )
+	passedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "passed_experiments",
+		Help:      "Total number of passed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kube_version"},
+	)
 
-    failedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "failed_experiments",
-        Help:      "Total number of failed experiments",
-    },
-    []string{"app_uid", "engine_name"},
-    )
-
+	failedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "failed_experiments",
+		Help:      "Total number of failed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kube_version"},
+	)
 )
 
 func contains(l []string, e string) bool {
-     for _, i := range l {
-         if i == e {
-             return true
-         }
-     }
-     return false
+	for _, i := range l {
+		if i == e {
+			return true
+		}
+	}
+	return false
 }
 
-func getEnv(key, fallback string)(string){
-        if value, ok := os.LookupEnv(key); ok {
-            return value
-        }
-        return fallback
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }
 
-func metrics(cfg *rest.Config, cEngine string, aUUID string, aNS string){
+func metrics(cfg *rest.Config, cEngine string, aUUID string, aNS string, kVer string) {
 
-   for {
-            // Get the chaos metrics for the specified chaosengine 
-            expTotal, passTotal, failTotal, expMap, err := util.GetChaosMetrics(cfg, cEngine, aNS)
-            if err != nil {
-                //panic(err.Error())
-                log.Fatal("Unable to get metrics: ", err.Error())
-            }
+	for {
+		// Get the chaos metrics for the specified chaosengine
+		expTotal, passTotal, failTotal, expMap, err := util.GetChaosMetrics(cfg, cEngine, aNS)
+		if err != nil {
+			//panic(err.Error())
+			log.Fatal("Unable to get metrics: ", err.Error())
+		}
 
-            // Define, register & set the dynamically obtained chaos metrics (experiment state)
-            for index, verdict := range expMap{
-                sanitizedExpName := strings.Replace(index, "-", "_", -1)
-                var (
-                    tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-                        Namespace: "c",
-                        Subsystem: "exp",
-                        Name:      sanitizedExpName,
-                        Help: "",
-                    },
-                    []string{"app_uid", "engine_name"},
-                    )
-                )
+		// Define, register & set the dynamically obtained chaos metrics (experiment state)
+		for index, verdict := range expMap {
+			sanitizedExpName := strings.Replace(index, "-", "_", -1)
+			var (
+				tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: "c",
+					Subsystem: "exp",
+					Name:      sanitizedExpName,
+					Help:      "",
+				},
+					[]string{"app_uid", "engine_name", "kube_version"},
+				)
+			)
 
-                if contains(registeredResultMetrics, sanitizedExpName) {
-                   prometheus.Unregister(tmpExp); prometheus.MustRegister(tmpExp)
-                   tmpExp.WithLabelValues(aUUID, cEngine).Set(verdict)
-                } else {
-                   prometheus.MustRegister(tmpExp)
-                   tmpExp.WithLabelValues(aUUID, cEngine).Set(verdict)
-                   registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
-                }
+			if contains(registeredResultMetrics, sanitizedExpName) {
+				prometheus.Unregister(tmpExp)
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(aUUID, cEngine, kVer).Set(verdict)
+			} else {
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(aUUID, cEngine, kVer).Set(verdict)
+				registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
+			}
 
-                // Set the fixed chaos metrics
-                experimentsTotal.WithLabelValues(aUUID, cEngine).Set(expTotal)
-                passedExperiments.WithLabelValues(aUUID, cEngine).Set(passTotal)
-                failedExperiments.WithLabelValues(aUUID, cEngine).Set(failTotal)
-            }
+			// Set the fixed chaos metrics
+			experimentsTotal.WithLabelValues(aUUID, cEngine, kVer).Set(expTotal)
+			passedExperiments.WithLabelValues(aUUID, cEngine, kVer).Set(passTotal)
+			failedExperiments.WithLabelValues(aUUID, cEngine, kVer).Set(failTotal)
+		}
 
-            time.Sleep(1000 * time.Millisecond)
-   }
+		time.Sleep(1000 * time.Millisecond)
+	}
 }
 
-func main(){
+func main() {
 
-    // Get app details & chaoengine name from ENV 
-    // Add checks for default
-    appUUID := os.Getenv("APP_UUID")
-    chaosengine := os.Getenv("CHAOSENGINE")
-    //appNS := os.Getenv("APP_NAMESPACE")
-    appNS := getEnv("APP_NAMESPACE", "default")
+	// Get app details & chaoengine name from ENV
+	// Add checks for default
+	appUUID := os.Getenv("APP_UUID")
+	chaosengine := os.Getenv("CHAOSENGINE")
+	//appNS := os.Getenv("APP_NAMESPACE")
+	appNS := getEnv("APP_NAMESPACE", "default")
 
-    flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
-    flag.Parse()
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
+	flag.Parse()
 
-    // Use in-cluster config if kubeconfig file not available
-    if kubeconfig == "" {
-        log.Info("using the in-cluster config")
-        config, err = rest.InClusterConfig()
-    } else {
-        log.Info("using configuration from: ", kubeconfig)
-        config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-    }
+	// Use in-cluster config if kubeconfig file not available
+	if kubeconfig == "" {
+		log.Info("using the in-cluster config")
+		config, err = rest.InClusterConfig()
+	} else {
+		log.Info("using configuration from: ", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
 
-    if err != nil {
-        panic(err.Error())
-    }
+	if err != nil {
+		panic(err.Error())
+	}
 
-    // Validate availability of mandatory ENV
-    if chaosengine == "" || appUUID == "" {
-        log.Fatal("ERROR: please specify correct APP_UUID & CHAOSENGINE ENVs")
-        os.Exit(1)
-    }
+	// Validate availability of mandatory ENV
+	if chaosengine == "" || appUUID == "" {
+		log.Fatal("ERROR: please specify correct APP_UUID & CHAOSENGINE ENVs")
+		os.Exit(1)
+	}
 
-    // Register the fixed (count) chaos metrics
-    prometheus.MustRegister(experimentsTotal)
-    prometheus.MustRegister(passedExperiments)
-    prometheus.MustRegister(failedExperiments)
+	kubeVersion, err := util.GetVersionInfo(config)
+	if err != nil {
+		log.Info("Unable to get Kubernetes Version")
+		kubeVersion = "N/A"
+	}
 
-    go metrics(config, chaosengine, appUUID, appNS)
+	// Register the fixed (count) chaos metrics
+	prometheus.MustRegister(experimentsTotal)
+	prometheus.MustRegister(passedExperiments)
+	prometheus.MustRegister(failedExperiments)
 
-    //This section will start the HTTP server and expose
-    //any metrics on the /metrics endpoint.
-    http.Handle("/metrics", promhttp.Handler())
-    log.Info("Beginning to serve on port :8080")
-    log.Fatal(http.ListenAndServe(":8080", nil))
+	go metrics(config, chaosengine, appUUID, appNS, kubeVersion)
+
+	//This section will start the HTTP server and expose
+	//any metrics on the /metrics endpoint.
+	http.Handle("/metrics", promhttp.Handler())
+	log.Info("Beginning to serve on port :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+
+	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+func GetVersionInfo(cfg *rest.Config) (string, error) {
+	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		fmt.Println("Unable to create the required ClientSet")
+		return "", err
+	}
+	version, err := clientSet.ServerVersion()
+	if err != nil {
+		fmt.Println("ClientSet is unable to communicate with the kubernetes cluster")
+		return "", err
+	}
+	return version.GitVersion, nil
+
+	/*fmt.Println("Server Major : ", version.Major)
+	fmt.Println("Server Minor : ", version.Minor)
+	fmt.Println("Server GitVersion : ", version.GitVersion)
+	fmt.Println("Server GitCommit : ", version.GitCommit)
+	fmt.Println("Server GitTreeState : ", version.GitTreeState)
+	fmt.Println("Server BuildDate : ", version.BuildDate)
+	fmt.Println("Server GoVersion : ", version.GoVersion)
+	fmt.Println("Server Compiler : ", version.Compiler)
+	fmt.Println("Server Platform : ", version.Platform)*/
+}

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	log "github.com/Sirupsen/logrus"
 	discovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"fmt"
-
+	log "github.com/Sirupsen/logrus"
 	discovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
@@ -10,12 +10,12 @@ import (
 func GetVersionInfo(cfg *rest.Config) (string, error) {
 	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		fmt.Println("Unable to create the required ClientSet")
+		log.Info("Unable to create the required ClientSet")
 		return "", err
 	}
 	version, err := clientSet.ServerVersion()
 	if err != nil {
-		fmt.Println("ClientSet is unable to communicate with the kubernetes cluster")
+		log.Info("ClientSet is unable to communicate with the kubernetes cluster")
 		return "", err
 	}
 	return version.GitVersion, nil


### PR DESCRIPTION
…porter

Changelog:
    - Added version.go in pkg.util
    - Changed the README.md for greater readability for starters
    - Added a function in main.go to fetch to KubeVersion
    - Modified all Prometheus Metrics to provide Kubernetes Version aswell
    - Used log.Info instead of log.fatal, if unable to fetch the Kubernetes Version, as it doesn't hinder the workflow of the code.
    - Assigned an "N/A" if unable to fetch the Version
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>