### PR TITLE
Added Kubernetes Version / OpenEBS Version to static metrics

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -85,7 +85,7 @@ func contains(l []string, e string) bool {
 }
 
 // getnamespaceEnv checks whether an ENV variable has been set, else sets a default value
-func getnamespaceEnv(key, fallback string) string {
+func getNamespaceEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
@@ -93,7 +93,7 @@ func getnamespaceEnv(key, fallback string) string {
 }
 
 // get
-func getopenebsEnv(key, fallback string) string {
+func getOpenebsEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
@@ -149,14 +149,12 @@ func main() {
 
 	// Get app details & chaoengine name from ENV
 	// Add checks for default
-	//applicationUUID := os.Getenv("APP_UUID")
-	applicationUUID := "1234"
-	//chaosEngine := os.Getenv("CHAOSENGINE")
-	chaosEngine := "engine8"
+	applicationUUID := os.Getenv("APP_UUID")
+	chaosEngine := os.Getenv("CHAOSENGINE")
 	//appNS := os.Getenv("APP_NAMESPACE")
-	appNamespace := getnamespaceEnv("APP_NAMESPACE", "default")
+	appNamespace := getNamespaceEnv("APP_NAMESPACE", "default")
 	//openEBS installation namespace
-	openebsNamespace := getopenebsEnv("OPENEBS_NAMESPACE", "openebs")
+	openebsNamespace := getOpenebsEnv("OPENEBS_NAMESPACE", "openebs")
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
 	flag.Parse()
@@ -180,13 +178,13 @@ func main() {
 		os.Exit(1)
 	}
 	// This function gets the kubernetes version
-	kubernetesVersion, err := version.GetkubernetesVersion(config)
+	kubernetesVersion, err := version.GetKubernetesVersion(config)
 	if err != nil {
 		log.Info("Unable to get Kubernetes Version : ", err)
 		//kubernetesVersion = "N/A"
 	}
 	// This function gets the openebs version
-	openebsVersion, err := version.GetopenebsVersion(config, openebsNamespace)
+	openebsVersion, err := version.GetOpenebsVersion(config, openebsNamespace)
 	if err != nil {
 		log.Info("Unable to get OpenEBS Version : ", err)
 		//openebsVersion = "N/A"

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,17 +1,17 @@
 /* The chaos exporter collects and exposes the following type of metrics:
 
    Fixed (always captured):
-     - Total number of chaos experiments 
-     - Total number of passed experiments 
+     - Total number of chaos experiments
+     - Total number of passed experiments
      - Total Number of failed experiments
- 
+
    Dynamic (experiment list may vary based on c.engine):
      - States of individual chaos experiments
      - {not-executed:0, running:1, fail:2, pass:3}
        TODO: Improve representaion of test state
 
    Common experiments include:
- 
+
      - pod_failure
      - container_kill
      - container_network_delay
@@ -21,18 +21,21 @@
 package main
 
 import (
-  "os"
-  "time"
-  //"fmt"
-  "flag"
-  "net/http"
-  "strings"
-  "github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
-  log "github.com/Sirupsen/logrus"
-  "github.com/prometheus/client_golang/prometheus"
-  "github.com/prometheus/client_golang/prometheus/promhttp"
-  "k8s.io/client-go/tools/clientcmd"
-  "k8s.io/client-go/rest"
+	"os"
+	"time"
+
+	//"fmt"
+	"flag"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
+	"github.com/litmuschaos/chaos-exporter/pkg/version"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Declare general variables (cluster ops, error handling, misc)
@@ -43,140 +46,152 @@ var registeredResultMetrics []string
 
 // Declare the fixed chaos metrics. Dynamic (testStatus) metrics are defined in metrics()
 var (
-    experimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "experiment_count",
-        Help:      "Total number of experiments executed by the chaos engine",
-    },
-    []string{"app_uid", "engine_name"},
-    )
+	experimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "experiment_count",
+		Help:      "Total number of experiments executed by the chaos engine",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
 
-    passedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "passed_experiments",
-        Help:      "Total number of passed experiments",
-    },
-    []string{"app_uid", "engine_name"},
-    )
+	passedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "passed_experiments",
+		Help:      "Total number of passed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
 
-    failedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-        Namespace: "c",
-        Subsystem: "engine",
-        Name:      "failed_experiments",
-        Help:      "Total number of failed experiments",
-    },
-    []string{"app_uid", "engine_name"},
-    )
-
+	failedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "failed_experiments",
+		Help:      "Total number of failed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
 )
 
 // contains checks if the a string is already part of a list of strings
 func contains(l []string, e string) bool {
-     for _, i := range l {
-         if i == e {
-             return true
-         }
-     }
-     return false
+	for _, i := range l {
+		if i == e {
+			return true
+		}
+	}
+	return false
 }
 
 // getEnv checks whether an ENV variable has been set, else sets a default value
-func getEnv(key, fallback string)(string){
-        if value, ok := os.LookupEnv(key); ok {
-            return value
-        }
-        return fallback
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }
 
+// exporter continuously collects the chaos metrics for a given chaosengine
+func exporter(cfg *rest.Config, chaosEngine string, appUUID string, appNS string, kubernetesVersion string, openebsVersion string) {
 
-// exporter continuously collects the chaos metrics for a given chaosengine 
-func exporter(cfg *rest.Config, chaosEngine string, appUUID string, appNS string){
+	for {
+		// Get the chaos metrics for the specified chaosengine
+		expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(cfg, chaosEngine, appNS)
+		if err != nil {
+			//panic(err.Error())
+			log.Fatal("Unable to get metrics: ", err.Error())
+		}
 
-   for {
-            // Get the chaos metrics for the specified chaosengine 
-            expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(cfg, chaosEngine, appNS)
-            if err != nil {
-                //panic(err.Error())
-                log.Fatal("Unable to get metrics: ", err.Error())
-            }
+		// Define, register & set the dynamically obtained chaos metrics (experiment state)
+		for index, verdict := range expMap {
+			sanitizedExpName := strings.Replace(index, "-", "_", -1)
+			var (
+				tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: "c",
+					Subsystem: "exp",
+					Name:      sanitizedExpName,
+					Help:      "",
+				},
+					[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+				)
+			)
 
-            // Define, register & set the dynamically obtained chaos metrics (experiment state)
-            for index, verdict := range expMap{
-                sanitizedExpName := strings.Replace(index, "-", "_", -1)
-                var (
-                    tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-                        Namespace: "c",
-                        Subsystem: "exp",
-                        Name:      sanitizedExpName,
-                        Help: "",
-                    },
-                    []string{"app_uid", "engine_name"},
-                    )
-                )
+			if contains(registeredResultMetrics, sanitizedExpName) {
+				prometheus.Unregister(tmpExp)
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
+			} else {
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
+				registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
+			}
 
-                if contains(registeredResultMetrics, sanitizedExpName) {
-                   prometheus.Unregister(tmpExp); prometheus.MustRegister(tmpExp)
-                   tmpExp.WithLabelValues(appUUID, chaosEngine).Set(verdict)
-                } else {
-                   prometheus.MustRegister(tmpExp)
-                   tmpExp.WithLabelValues(appUUID, chaosEngine).Set(verdict)
-                   registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
-                }
+			// Set the fixed chaos metrics
+			experimentsTotal.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(expTotal)
+			passedExperiments.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(passTotal)
+			failedExperiments.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(failTotal)
+		}
 
-                // Set the fixed chaos metrics
-                experimentsTotal.WithLabelValues(appUUID, chaosEngine).Set(expTotal)
-                passedExperiments.WithLabelValues(appUUID, chaosEngine).Set(passTotal)
-                failedExperiments.WithLabelValues(appUUID, chaosEngine).Set(failTotal)
-            }
-
-            time.Sleep(1000 * time.Millisecond)
-   }
+		time.Sleep(1000 * time.Millisecond)
+	}
 }
 
-func main(){
+func main() {
 
-    // Get app details & chaoengine name from ENV 
-    // Add checks for default
-    applicationUUID := os.Getenv("APP_UUID")
-    chaosEngine := os.Getenv("CHAOSENGINE")
-    //appNS := os.Getenv("APP_NAMESPACE")
-    appNamespace := getEnv("APP_NAMESPACE", "default")
+	// Get app details & chaoengine name from ENV
+	// Add checks for default
+	//applicationUUID := os.Getenv("APP_UUID")
+	applicationUUID := "1234"
+	//chaosEngine := os.Getenv("CHAOSENGINE")
+	chaosEngine := "engine8"
+	//appNS := os.Getenv("APP_NAMESPACE")
+	appNamespace := getEnv("APP_NAMESPACE", "default")
 
-    flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
-    flag.Parse()
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
+	flag.Parse()
 
-    // Use in-cluster config if kubeconfig file not available
-    if kubeconfig == "" {
-        log.Info("using the in-cluster config")
-        config, err = rest.InClusterConfig()
-    } else {
-        log.Info("using configuration from: ", kubeconfig)
-        config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-    }
+	// Use in-cluster config if kubeconfig file not available
+	if kubeconfig == "" {
+		log.Info("using the in-cluster config")
+		config, err = rest.InClusterConfig()
+	} else {
+		log.Info("using configuration from: ", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
 
-    if err != nil {
-        panic(err.Error())
-    }
+	if err != nil {
+		panic(err.Error())
+	}
 
-    // Validate availability of mandatory ENV
-    if chaosEngine == "" || applicationUUID == "" {
-        log.Fatal("ERROR: please specify correct APP_UUID & CHAOSENGINE ENVs")
-        os.Exit(1)
-    }
+	// Validate availability of mandatory ENV
+	if chaosEngine == "" || applicationUUID == "" {
+		log.Fatal("ERROR: please specify correct APP_UUID & CHAOSENGINE ENVs")
+		os.Exit(1)
+	}
+	// This function gets the kubernetes version
+	kubernetesVersion, err := version.GetkubernetesVersion(config)
+	if err != nil {
+		log.Info("Unable to get Kubernetes Version : ", err)
+		//kubernetesVersion = "N/A"
+	}
+	// This function gets the openebs version
+	openebsVersion, err := version.GetopenebsVersion(config)
+	if err != nil {
+		log.Info("Unable to get OpenEBS Version : ", err)
+		//openebsVersion = "N/A"
+	}
+	// Register the fixed (count) chaos metrics
+	prometheus.MustRegister(experimentsTotal)
+	prometheus.MustRegister(passedExperiments)
+	prometheus.MustRegister(failedExperiments)
 
-    // Register the fixed (count) chaos metrics
-    prometheus.MustRegister(experimentsTotal)
-    prometheus.MustRegister(passedExperiments)
-    prometheus.MustRegister(failedExperiments)
+	// Trigger the chaos metrics collection
+	go exporter(config, chaosEngine, applicationUUID, appNamespace, kubernetesVersion, openebsVersion)
 
-    // Trigger the chaos metrics collection
-    go exporter(config, chaosEngine, applicationUUID, appNamespace)
-
-    //This section will start the HTTP server and expose
-    //any metrics on the /metrics endpoint.
-    http.Handle("/metrics", promhttp.Handler())
-    log.Info("Beginning to serve on port :8080")
-    log.Fatal(http.ListenAndServe(":8080", nil))
+	//This section will start the HTTP server and expose
+	//any metrics on the /metrics endpoint.
+	http.Handle("/metrics", promhttp.Handler())
+	log.Info("Beginning to serve on port :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -84,8 +84,16 @@ func contains(l []string, e string) bool {
 	return false
 }
 
-// getEnv checks whether an ENV variable has been set, else sets a default value
-func getEnv(key, fallback string) string {
+// getnamespaceEnv checks whether an ENV variable has been set, else sets a default value
+func getnamespaceEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+// get
+func getopenebsEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
@@ -146,7 +154,9 @@ func main() {
 	//chaosEngine := os.Getenv("CHAOSENGINE")
 	chaosEngine := "engine8"
 	//appNS := os.Getenv("APP_NAMESPACE")
-	appNamespace := getEnv("APP_NAMESPACE", "default")
+	appNamespace := getnamespaceEnv("APP_NAMESPACE", "default")
+	//openEBS installation namespace
+	openebsNamespace := getopenebsEnv("OPENEBS_NAMESPACE", "openebs")
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
 	flag.Parse()
@@ -176,7 +186,7 @@ func main() {
 		//kubernetesVersion = "N/A"
 	}
 	// This function gets the openebs version
-	openebsVersion, err := version.GetopenebsVersion(config)
+	openebsVersion, err := version.GetopenebsVersion(config, openebsNamespace)
 	if err != nil {
 		log.Info("Unable to get OpenEBS Version : ", err)
 		//openebsVersion = "N/A"

--- a/cmd/exporter/main_test.go
+++ b/cmd/exporter/main_test.go
@@ -5,13 +5,11 @@ TODO: Test functions for chaos exporter
 package main
 
 import (
-    "fmt"
-    "testing"
+	"fmt"
+	"testing"
 )
 
 // TestChaosExporter is a sample test function
-func TestChaosExporter(t *testing.T){
-    fmt.Println("..Test Chaos Exporter..")
+func TestChaosExporter(t *testing.T) {
+	fmt.Println("..Test Chaos Exporter..")
 }
-
-

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,90 @@
+# Litmus Chaos Exporter
+
+- This is a custom prometheus exporter to expose Litmus Chaos metrics. 
+  To learn more about Litmus Chaos Experiments & the Litmus Chaos Operator, 
+  visit this link: [Litmus Docs](https://docs.litmuschaos.io/) 
+
+- The exporter is tied to a Chaosengine custom resource, which, 
+  in-turn is associated with a given application deployment.
+
+- The exporter is typically deployed as a to to the Litmus Experiment
+  Runner container in the engine-runner pod, but can be launched as a
+  separate deployment as well. 
+
+- Two types of metrics are exposed: 
+
+  - Fixed: TotalExperimentCount, TotalPassedTests, TotalFailedTests which are derived 
+    from the ChaosEngine specification upfront
+
+  - Dymanic: Individual Experiment Run Status. The list of experiments may 
+    vary across ChaosEngines (or newer tests may be patched into it. 
+    The exporter reports experiment status as per list in the chaosengine
+
+- The metrics are of type Gauge, w/ each of the status metrics mapped to a 
+  numeric value(not-executed:0, running:1, fail:2, pass:3)
+
+- The metrics carry the application_uuid as label (this has to be passed as ENV)
+## Steps to build & deploy: 
+
+### Local Machine 
+
+#### Pre-requisites:
+
+- A Working Local Kubernetes Cluster (Eg: Minikube or Vagrant)
+  - Set each of these Custom Resource Definition in your Kubernetes Cluster
+  - For ChaosEngine : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine_crd.yaml
+  - For ChaosResult : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosresults_crd.yaml
+  - For ChaosExperiment: https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosexperiment_crd.yaml
+  For information on these Custom Resources, please check this link : https://docs.litmuschaos.io/docs/next/co-components.html
+- Kube-config path of your local Kubernetes Cluster
+- `$GOPATH` set to your working directory
+
+### Further Steps: 
+
+The following steps are required to create sample chaos-related custom resources in order to visualize the metrics gathered by the chaos exporter
+
+- Clone this repo into your $GOPATH/litmuschaos"
+  `git clone https://github.com/litmuschaos/chaos-exporter`
+- Set an APP_UUID in the `~/.bashrc` or the `~/.profile`, add this command to set a default
+- Now, start your Local Cluster, (this guide helps in `minikube` but can be used for other offline clusters as well)
+- Create Kubernetes CR's(Custom Resources) for the litmus operator, link down below:
+- Now, as you have created the CustomResourceDefinition, Now it time to create the CustomResources for these definition above:
+  - For Default ChaosEngine : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosengine.yaml
+    NOTE THAT THIS CHAOSENGINE COMES WITH A DEFAULT NAME ASSIGNED WITH IT WHICH IS : `engine-nginx`  you would need this afterwards
+  - For Default ChaosResult : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosresult.yaml
+  - For the Default Experiments (Pod Delete Experiment) : https://github.com/litmuschaos/chaos-operator/blob/master/deploy/crds/chaosexperiment.yaml
+- As you have created the ChaosEngine, now again make changes in the `~/.bashrc` or the `~/.profile`, and the add this statement `export CHAOSENGINE=engine-nginx`, if you have changed the ChaosEngine name, then make those changes here as well.
+- Execute the command `source ~/.bashrc` or `source ~/.profile` according to the file you made changes in
+- Now try the command `echo $APP_UUID` and `echo $CHAOSENGINE` , and check the outputs annd verify if they are set according to your preference.
+  - APP_UUID is derived from the app to be added as a metric label for Prometheus Exporter, as same for the ChaosEngine.
+- Run the command `make build` in the root directory.
+- Find your kube-config file for your local cluster.
+  - For minikube it is located in the directory `/home/user_name/.kube/config`, keep this path handy with you
+- After building the file execute this command `sudo ./main -kubeconfig=path_for_the_kubeconfig`
+- Execute `curl 127.0.0.1:8080/metrics | less` to view metrics
+
+### On Kubernetes Cluster
+
+- Install the RBAC (serviceaccount, role, rolebinding) as per deploy/rbac.md
+
+- Deploy the chaos-exporter.yaml 
+
+- From a cluster node, execute `curl <exporter-service-ip>:8080/metrics` 
+
+### Example Metrics
+
+```
+# HELP c_engine_experiment_count Total number of experiments executed by the chaos engine
+# TYPE c_engine_experiment_count gauge
+c_engine_experiment_count{app_uid="1234",engine_name="engine-nginx",kubernetes_version="v1.15.0",openebs_version="1.0"} 1
+# HELP c_engine_failed_experiments Total number of failed experiments
+# TYPE c_engine_failed_experiments gauge
+c_engine_failed_experiments{app_uid="1234",engine_name="engine-nginx",kubernetes_version="v1.15.0",openebs_version="1.0"} 0
+# HELP c_engine_passed_experiments Total number of passed experiments
+# TYPE c_engine_passed_experiments gauge
+c_engine_passed_experiments{app_uid="1234",engine_name="engine-nginx",kubernetes_version="v1.15.0",openebs_version="1.0"} 1
+# HELP c_exp_pod_delete 
+# TYPE c_exp_pod_delete gauge
+c_exp_pod_delete{app_uid="1234",engine_name="engine-nginx",kubernetes_version="v1.15.0",openebs_version="N/A"} 3
+```
+

--- a/pkg/chaosmetrics/scrapecr.go
+++ b/pkg/chaosmetrics/scrapecr.go
@@ -1,15 +1,15 @@
 package chaosmetrics
 
 import (
-    "fmt"
-    "strings"
-    "k8s.io/client-go/kubernetes/scheme"
-    "k8s.io/client-go/rest"
-    // auth for gcp: optional
-    _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
-    clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	"fmt"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"strings"
+	// auth for gcp: optional
+	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // Holds list of experiments in a chaosengine
@@ -23,98 +23,98 @@ var statusmap map[string]float64
 
 // Holds a lookup of result: numericValue
 var numericstatus = map[string]float64{
-         "not-executed": 0,
-         "running":      1,
-         "fail":         2,
-         "pass":         3,
+	"not-executed": 0,
+	"running":      1,
+	"fail":         2,
+	"pass":         3,
 }
 
 // Holds Error type
 var err error
 
-// Utility fn to return numeric value for a result 
-func statusConv (expstatus string)(numeric float64){
-    if numeric, ok := numericstatus[expstatus]; ok {
-        return numeric
-        //fmt.Printf("%v", numeric)
-    }
-    //return 127
-    return 0
+// Utility fn to return numeric value for a result
+func statusConv(expstatus string) (numeric float64) {
+	if numeric, ok := numericstatus[expstatus]; ok {
+		return numeric
+		//fmt.Printf("%v", numeric)
+	}
+	//return 127
+	return 0
 }
 
 /* Exported function to gather chaos metrics
 
    - TODO: Update the chaosresult to carry verdict alone. Status & Verdict are redundant
-*/ 
+*/
 
-// GetChaosMetrics returns chaos metrics for a given chaosengine 
-func GetLitmusChaosMetrics(cfg *rest.Config, cEngine string, ns string)(totalExpCount, totalPassedExp, totalFailedExp float64, rMap map[string]float64, err error){
+// GetChaosMetrics returns chaos metrics for a given chaosengine
+func GetLitmusChaosMetrics(cfg *rest.Config, cEngine string, ns string) (totalExpCount, totalPassedExp, totalFailedExp float64, rMap map[string]float64, err error) {
 
-    v1alpha1.AddToScheme(scheme.Scheme)
-    clientSet, err := clientV1alpha1.NewForConfig(cfg)
-    if err != nil {
-        return 0, 0, 0, nil, err
-    }
+	v1alpha1.AddToScheme(scheme.Scheme)
+	clientSet, err := clientV1alpha1.NewForConfig(cfg)
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
 
-    engine, err := clientSet.ChaosEngines(ns).Get(cEngine, metav1.GetOptions{})
-    if err != nil {
-        return 0, 0, 0, nil, err
-    }
+	engine, err := clientSet.ChaosEngines(ns).Get(cEngine, metav1.GetOptions{})
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
 
-    /////////////////////////////////////////////////////////
-    /*METRIC*/
-    totalExpCount = float64(len(engine.Spec.Experiments))  //
-    /////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	/*METRIC*/
+	totalExpCount = float64(len(engine.Spec.Experiments)) //
+	/////////////////////////////////////////////////////////
 
-    for _, element:= range engine.Spec.Experiments{
-        chaosexperimentlist = append(chaosexperimentlist, element.Name)
-    }
+	for _, element := range engine.Spec.Experiments {
+		chaosexperimentlist = append(chaosexperimentlist, element.Name)
+	}
 
-    // Initialize the chaosresult map before entering loop
-    chaosresultmap := make(map[string]string)
+	// Initialize the chaosresult map before entering loop
+	chaosresultmap := make(map[string]string)
 
-    // Set default values on the chaosresult map before populating w/ actual values
-    //for _, test:= range chaosexperimentlist{
+	// Set default values on the chaosresult map before populating w/ actual values
+	//for _, test:= range chaosexperimentlist{
 
-    for _, test:= range chaosexperimentlist{
-        chaosresultname := fmt.Sprintf("%s-%s", cEngine, test)
-        testresultdump, err:= clientSet.ChaosResults(ns).Get(chaosresultname, metav1.GetOptions{})
-        if err != nil {
-            if strings.Contains(err.Error(), "not found"){
-                // lack of result cr indicates experiment not executed
-                //chaosresultmap[chaosresultname] = "not-executed"
-                chaosresultmap[test] = "not-executed"
-            }
-            //return 0, 0, 0, nil, err
-        }
-        result := testresultdump.Spec.ExperimentStatus.Verdict
-        //chaosresultmap[chaosresultname] = result
-        chaosresultmap[test] = result
-    }
+	for _, test := range chaosexperimentlist {
+		chaosresultname := fmt.Sprintf("%s-%s", cEngine, test)
+		testresultdump, err := clientSet.ChaosResults(ns).Get(chaosresultname, metav1.GetOptions{})
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				// lack of result cr indicates experiment not executed
+				//chaosresultmap[chaosresultname] = "not-executed"
+				chaosresultmap[test] = "not-executed"
+			}
+			//return 0, 0, 0, nil, err
+		}
+		result := testresultdump.Spec.ExperimentStatus.Verdict
+		//chaosresultmap[chaosresultname] = result
+		chaosresultmap[test] = result
+	}
 
-    pcount, fcount := 0, 0
-    for _, verdict := range chaosresultmap{
-        if verdict == "pass" {
-            pcount++
-        } else if verdict == "fail" {
-            fcount++
-        }
-    }
+	pcount, fcount := 0, 0
+	for _, verdict := range chaosresultmap {
+		if verdict == "pass" {
+			pcount++
+		} else if verdict == "fail" {
+			fcount++
+		}
+	}
 
-    /////////////////////////////////////////////////
-    /*METRIC*/                                     //
-    totalPassedExp = float64(pcount)               //
-    totalFailedExp = float64(fcount)               //
-    /////////////////////////////////////////////////
-    //fmt.Printf("%+v %+v %+v\n", totalExpCount, totalPassedExp, totalFailedExp)
+	/////////////////////////////////////////////////
+	/*METRIC*/                       //
+	totalPassedExp = float64(pcount) //
+	totalFailedExp = float64(fcount) //
+	/////////////////////////////////////////////////
+	//fmt.Printf("%+v %+v %+v\n", totalExpCount, totalPassedExp, totalFailedExp)
 
-    //Map verdict to numerical values {0-notstarted, 1-running, 2-fail, 3-pass}
-    statusmap := make(map[string]float64)
-    for index, status := range chaosresultmap{
-        val := statusConv(status)
-        statusmap[index] = val
-    }
-    fmt.Printf("%+v\n", statusmap)
+	//Map verdict to numerical values {0-notstarted, 1-running, 2-fail, 3-pass}
+	statusmap := make(map[string]float64)
+	for index, status := range chaosresultmap {
+		val := statusConv(status)
+		statusmap[index] = val
+	}
+	fmt.Printf("%+v\n", statusmap)
 
-    return totalExpCount, totalPassedExp, totalFailedExp, statusmap, nil
+	return totalExpCount, totalPassedExp, totalFailedExp, statusmap, nil
 }

--- a/pkg/chaosmetrics/scrapecr.go
+++ b/pkg/chaosmetrics/scrapecr.go
@@ -49,7 +49,7 @@ func statusConv(expstatus string) (numeric float64) {
    - TODO: Update the chaosresult to carry verdict alone. Status & Verdict are redundant
 */
 
-// GetChaosMetrics returns chaos metrics for a given chaosengine
+// GetLitmusChaosMetrics returns chaos metrics for a given chaosengine
 func GetLitmusChaosMetrics(cfg *rest.Config, cEngine string, ns string) (totalExpCount, totalPassedExp, totalFailedExp float64, rMap map[string]float64, err error) {
 
 	v1alpha1.AddToScheme(scheme.Scheme)

--- a/pkg/chaosmetrics/scrapecr.go
+++ b/pkg/chaosmetrics/scrapecr.go
@@ -2,14 +2,16 @@ package chaosmetrics
 
 import (
 	"fmt"
+	"strings"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"strings"
+
 	// auth for gcp: optional
+	//_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
 	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // Holds list of experiments in a chaosengine

--- a/pkg/clientset/v1alpha1/api.go
+++ b/pkg/clientset/v1alpha1/api.go
@@ -1,52 +1,52 @@
 package v1alpha1
 
 import (
-    "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
-    "k8s.io/apimachinery/pkg/runtime/schema"
-    "k8s.io/apimachinery/pkg/runtime/serializer"
-    "k8s.io/client-go/kubernetes/scheme"
-    "k8s.io/client-go/rest"
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
-//ExampleV1Alpha1Interface type defines chaosEngines & chaosResults 
+//ExampleV1Alpha1Interface type defines chaosEngines & chaosResults
 type ExampleV1Alpha1Interface interface {
-    // ChaosEngines with namespace attribute 
-    ChaosEngines(namespace string) ChaosEngineInterface
-    // ChaosResults with namespace attribute
-    ChaosResults(namespace string) ChaosResultInterface
+	// ChaosEngines with namespace attribute
+	ChaosEngines(namespace string) ChaosEngineInterface
+	// ChaosResults with namespace attribute
+	ChaosResults(namespace string) ChaosResultInterface
 }
 
 //ExampleV1Alpha1Client type defines the rest client for chaos resources
 type ExampleV1Alpha1Client struct {
-    restClient rest.Interface
+	restClient rest.Interface
 }
 
 //NewForConfig returns the kubeclient for the config provided
 func NewForConfig(c *rest.Config) (*ExampleV1Alpha1Client, error) {
-    config := *c
-    config.ContentConfig.GroupVersion = &schema.GroupVersion{Group: v1alpha1.GroupName, Version: v1alpha1.GroupVersion}
-    config.APIPath = "/apis"
-    config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
-    config.UserAgent = rest.DefaultKubernetesUserAgent()
+	config := *c
+	config.ContentConfig.GroupVersion = &schema.GroupVersion{Group: v1alpha1.GroupName, Version: v1alpha1.GroupVersion}
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
 
-    client, err := rest.RESTClientFor(&config)
-    if err != nil {
-        return nil, err
-    }
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
 
-    return &ExampleV1Alpha1Client{restClient: client}, nil
+	return &ExampleV1Alpha1Client{restClient: client}, nil
 }
 
 func (c *ExampleV1Alpha1Client) ChaosEngines(namespace string) ChaosEngineInterface {
-    return &chaosEngineClient{
-        restClient: c.restClient,
-	ns:         namespace,
-    }
+	return &chaosEngineClient{
+		restClient: c.restClient,
+		ns:         namespace,
+	}
 }
 
 func (c *ExampleV1Alpha1Client) ChaosResults(namespace string) ChaosResultInterface {
-    return &chaosResultClient{
-	restClient: c.restClient,
-	ns:         namespace,
-    }
+	return &chaosResultClient{
+		restClient: c.restClient,
+		ns:         namespace,
+	}
 }

--- a/pkg/clientset/v1alpha1/chaosengines.go
+++ b/pkg/clientset/v1alpha1/chaosengines.go
@@ -1,61 +1,60 @@
 package v1alpha1
 
 import (
-    "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/client-go/kubernetes/scheme"
-    "k8s.io/client-go/rest"
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
 type ChaosEngineInterface interface {
-    List(opts metav1.ListOptions) (*v1alpha1.ChaosEngineList, error)
-    Get(name string, options metav1.GetOptions) (*v1alpha1.ChaosEngine, error)
-    Create(*v1alpha1.ChaosEngine) (*v1alpha1.ChaosEngine, error)
-    // ...
+	List(opts metav1.ListOptions) (*v1alpha1.ChaosEngineList, error)
+	Get(name string, options metav1.GetOptions) (*v1alpha1.ChaosEngine, error)
+	Create(*v1alpha1.ChaosEngine) (*v1alpha1.ChaosEngine, error)
+	// ...
 }
 
 type chaosEngineClient struct {
-    restClient rest.Interface
-    ns         string
+	restClient rest.Interface
+	ns         string
 }
 
 func (c *chaosEngineClient) List(opts metav1.ListOptions) (*v1alpha1.ChaosEngineList, error) {
-    result := v1alpha1.ChaosEngineList{}
-    err := c.restClient.
-	    Get().
-	    Namespace(c.ns).
-	    Resource("chaosengines").
-	    VersionedParams(&opts, scheme.ParameterCodec).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosEngineList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource("chaosengines").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
 
 func (c *chaosEngineClient) Get(name string, opts metav1.GetOptions) (*v1alpha1.ChaosEngine, error) {
-    result := v1alpha1.ChaosEngine{}
-    err := c.restClient.
-	    Get().
-	    Namespace(c.ns).
-	    Resource("chaosengines").
-	    Name(name).
-	    VersionedParams(&opts, scheme.ParameterCodec).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosEngine{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource("chaosengines").
+		Name(name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
 
 func (c *chaosEngineClient) Create(chaosengine *v1alpha1.ChaosEngine) (*v1alpha1.ChaosEngine, error) {
-    result := v1alpha1.ChaosEngine{}
-    err := c.restClient.
-	    Post().
-	    Namespace(c.ns).
-	    Resource("chaosengines").
-	    Body(chaosengine).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosEngine{}
+	err := c.restClient.
+		Post().
+		Namespace(c.ns).
+		Resource("chaosengines").
+		Body(chaosengine).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
-

--- a/pkg/clientset/v1alpha1/chaosresults.go
+++ b/pkg/clientset/v1alpha1/chaosresults.go
@@ -1,64 +1,64 @@
 package v1alpha1
 
 import (
-    "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    //"k8s.io/apimachinery/pkg/watch"
-    "k8s.io/client-go/kubernetes/scheme"
-    "k8s.io/client-go/rest"
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
 type ChaosResultInterface interface {
-    List(opts metav1.ListOptions) (*v1alpha1.ChaosResultList, error)
-    Get(name string, options metav1.GetOptions) (*v1alpha1.ChaosResult, error)
-    Create(*v1alpha1.ChaosResult) (*v1alpha1.ChaosResult, error)
-    // Watch(opts metav1.ListOptions) (watch.Interface, error)
-    // ...
+	List(opts metav1.ListOptions) (*v1alpha1.ChaosResultList, error)
+	Get(name string, options metav1.GetOptions) (*v1alpha1.ChaosResult, error)
+	Create(*v1alpha1.ChaosResult) (*v1alpha1.ChaosResult, error)
+	// Watch(opts metav1.ListOptions) (watch.Interface, error)
+	// ...
 }
 
 type chaosResultClient struct {
-    restClient rest.Interface
-    ns         string
+	restClient rest.Interface
+	ns         string
 }
 
 func (c *chaosResultClient) List(opts metav1.ListOptions) (*v1alpha1.ChaosResultList, error) {
-    result := v1alpha1.ChaosResultList{}
-    err := c.restClient.
-	    Get().
-	    Namespace(c.ns).
-	    Resource("chaosresults").
-	    VersionedParams(&opts, scheme.ParameterCodec).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosResultList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource("chaosresults").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
 
 func (c *chaosResultClient) Get(name string, opts metav1.GetOptions) (*v1alpha1.ChaosResult, error) {
-    result := v1alpha1.ChaosResult{}
-    err := c.restClient.
-	    Get().
-	    Namespace(c.ns).
-	    Resource("chaosresults").
-	    Name(name).
-	    VersionedParams(&opts, scheme.ParameterCodec).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosResult{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource("chaosresults").
+		Name(name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
 
 func (c *chaosResultClient) Create(chaosresult *v1alpha1.ChaosResult) (*v1alpha1.ChaosResult, error) {
-    result := v1alpha1.ChaosResult{}
-    err := c.restClient.
-	    Post().
-	    Namespace(c.ns).
-	    Resource("chaosresults").
-	    Body(chaosresult).
-	    Do().
-	    Into(&result)
+	result := v1alpha1.ChaosResult{}
+	err := c.restClient.
+		Post().
+		Namespace(c.ns).
+		Resource("chaosresults").
+		Body(chaosresult).
+		Do().
+		Into(&result)
 
-    return &result, err
+	return &result, err
 }
 
 /*

--- a/pkg/version/kubernetesVersion.go
+++ b/pkg/version/kubernetesVersion.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// Function to get kubernetes Version
+// GetkubernetesVersion function gets kubernetes Version
 func GetkubernetesVersion(cfg *rest.Config) (string, error) {
 	// function to get Kubernetes Version
 	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)

--- a/pkg/version/kubernetesVersion.go
+++ b/pkg/version/kubernetesVersion.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// GetkubernetesVersion function gets kubernetes Version
-func GetkubernetesVersion(cfg *rest.Config) (string, error) {
+// GetKubernetesVersion function gets kubernetes Version
+func GetKubernetesVersion(cfg *rest.Config) (string, error) {
 	// function to get Kubernetes Version
 	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {

--- a/pkg/version/kubernetesVersion.go
+++ b/pkg/version/kubernetesVersion.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"fmt"
+
+	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// Function to get kubernetes Version
+func GetkubernetesVersion(cfg *rest.Config) (string, error) {
+	// function to get Kubernetes Version
+	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		fmt.Println("Unable to create the required ClientSet")
+		return "N/A", err
+	}
+	version, err := clientSet.ServerVersion()
+	if err != nil {
+		fmt.Println("ClientSet is unable to communicate with the kubernetes cluster")
+		return "N/A", err
+	}
+	return version.GitVersion, nil
+
+	/*fmt.Println("Server Major : ", version.Major)
+	fmt.Println("Server Minor : ", version.Minor)
+	fmt.Println("Server GitVersion : ", version.GitVersion)
+	fmt.Println("Server GitCommit : ", version.GitCommit)
+	fmt.Println("Server GitTreeState : ", version.GitTreeState)
+	fmt.Println("Server BuildDate : ", version.BuildDate)
+	fmt.Println("Server GoVersion : ", version.GoVersion)
+	fmt.Println("Server Compiler : ", version.Compiler)
+	fmt.Println("Server Platform : ", version.Platform)*/
+}

--- a/pkg/version/openebsVersion.go
+++ b/pkg/version/openebsVersion.go
@@ -9,8 +9,8 @@ import (
 
 var openebsVersion string
 
-// GetopenebsVersion function fetchs the OpenEBS version
-func GetopenebsVersion(cfg *rest.Config, namespace string) (string, error) {
+// GetOpenebsVersion function fetchs the OpenEBS version
+func GetOpenebsVersion(cfg *rest.Config, namespace string) (string, error) {
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		log.Info("Unable to create the required ClientSet")

--- a/pkg/version/openebsVersion.go
+++ b/pkg/version/openebsVersion.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	log "github.com/Sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var openebsVersion string
+
+// function to get the OpenEBS Version for metrics
+func GetopenebsVersion(cfg *rest.Config) (string, error) {
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Info("Unable to create the required ClientSet")
+		return "N/A", err
+	}
+	list, err := clientSet.CoreV1().Pods("openebs").List(metav1.ListOptions{
+		LabelSelector: "openebs.io/component-name=maya-apiserver",
+		Limit:         1,
+	})
+	if err != nil {
+		log.Info("Unable to fing openebs / maya api-server")
+		return "N/A", err
+	}
+	if len(list.Items) == 0 {
+		log.Info("No resources with labels 'openebs.io/component-name=maya-apiserver' found")
+		return "N/A", err
+	}
+	for _, v := range list.Items {
+		openebsVersion = v.GetLabels()["openebs.io/version"]
+	}
+
+	return openebsVersion, err
+
+}

--- a/pkg/version/openebsVersion.go
+++ b/pkg/version/openebsVersion.go
@@ -9,19 +9,19 @@ import (
 
 var openebsVersion string
 
-// function to get the OpenEBS Version for metrics
-func GetopenebsVersion(cfg *rest.Config) (string, error) {
+// GetopenebsVersion function fetchs the OpenEBS version
+func GetopenebsVersion(cfg *rest.Config, namespace string) (string, error) {
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		log.Info("Unable to create the required ClientSet")
 		return "N/A", err
 	}
-	list, err := clientSet.CoreV1().Pods("openebs").List(metav1.ListOptions{
+	list, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{
 		LabelSelector: "openebs.io/component-name=maya-apiserver",
 		Limit:         1,
 	})
 	if err != nil {
-		log.Info("Unable to fing openebs / maya api-server")
+		log.Info("Unable to find openebs / maya api-server")
 		return "N/A", err
 	}
 	if len(list.Items) == 0 {


### PR DESCRIPTION
Issues Solved
        - Kubernetes Version
	- OpenEBS Version
	- Created contributing.md

Changelog:
	- Created a dir, /pkg/version
	- Added 2 codes, int dir version, to get the kubernetes and openebs version
	- Created a contributing.md
	- Made changes in main.go, to fetch the versions, and pass then into metrics


The output of the metrics should look like this :

```
# HELP c_engine_experiment_count Total number of experiments executed by the chaos engine
# TYPE c_engine_experiment_count gauge
c_engine_experiment_count{app_uid="1234",engine_name="engine8",kubernetes_version="v1.15.0",openebs_version="1.1.0"} 1
# HELP c_engine_failed_experiments Total number of failed experiments
# TYPE c_engine_failed_experiments gauge
c_engine_failed_experiments{app_uid="1234",engine_name="engine8",kubernetes_version="v1.15.0",openebs_version="1.1.0"} 0
# HELP c_engine_passed_experiments Total number of passed experiments
# TYPE c_engine_passed_experiments gauge
c_engine_passed_experiments{app_uid="1234",engine_name="engine8",kubernetes_version="v1.15.0",openebs_version="1.1.0"} 1
# HELP c_exp_pod_delete 
# TYPE c_exp_pod_delete gauge
c_exp_pod_delete{app_uid="1234",engine_name="engine8",kubernetes_version="v1.15.0",openebs_version="1.1.0"} 3
```
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>