### PR TITLE
(feat)bdd: include BDD tests to verify successful chaos metrics collection by exporter 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     - CHAOSENGINE=engine-nginx
-    - APP_UUID=1232
+    - APP_UUID=1234
     - APP_NAMESPACE=litmus
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,46 @@
-dist: trusty
 sudo: required
-install: true
+dist: xenial
+env:
+  global:
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_HOME=$HOME
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBECONFIG=$HOME/.kube/config
+    - CHAOSENGINE=engine-nginx
+    - APP_UUID=1232
+    - APP_NAMESPACE=litmus
+services:
+  - docker
 language: go
 go:
   - 1.11.2
-env:
-  global:
-    - GOARCH=amd64
-before_install:
-  - sleep 15
-  - sudo apt-get install -y
-  - sudo apt-get install -y curl
+
+addons:
+  apt:
+    update: true
+
+before_script:
+  # Download kubectl, which is a requirement for using minikube.
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  # Download minikube.
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - mkdir -p $HOME/.kube $HOME/.minikube
+  - touch $KUBECONFIG
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0
+  - "sudo chown -R travis: /home/travis/.minikube/"
+  # Wait for Kubernetes to be up and ready.
+  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
 script:
+  # Installing Go Dependencies
   - make godeps
-  - make all
+  # bdd testing dependencies - ginkgo and gomega 
+  - make bdddeps
+  # Running all go tests
+  - make test
+
+after_success:
+  - sudo minikube delete
+  - make dockerops

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:16.04
-
-COPY ./exporter /
-
-EXPOSE 8080
-
-CMD ["/exporter"]
-
-
-
-
+FROM golang:alpine
+RUN mkdir -p github.com/litmuschaos/chaos-exporter
+ADD . /github.com/litmuschaos/chaos-exporter
+WORKDIR /github.com/litmuschaos/chaos-exporter
+RUN apk update && apk add git 
+RUN pwd
+RUN go get github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics
+RUN go get github.com/Sirupsen/logrus
+RUN go get github.com/prometheus/client_golang/prometheus
+RUN go get k8s.io/client-go/rest
 

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,6 @@ bdddeps:
 
 	# @go get -u github.com/onsi/ginkgo
 	# @go get -u github.com/onsi/gomega 
-	# kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
-	# kubectl create ns litmus
-	nohup go run cmd/exporter/main.go -kubeconfig=$(HOME)/.kube/config & 
+	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
+	kubectl create ns litmus
+	# nohup go run cmd/exporter/main.go -kubeconfig=$(HOME)/.kube/config & 

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,7 @@ bdddeps:
 	@echo "bdd test dependencies"
 	@echo "INFO:\tverifying dependencies for bdddeps ..."
 	@echo "------------------"
-
-	# @go get -u github.com/onsi/ginkgo
-	# @go get -u github.com/onsi/gomega 
+	@go get -u github.com/onsi/ginkgo
+	@go get -u github.com/onsi/gomega 
 	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
 	kubectl create ns litmus
-	# nohup go run cmd/exporter/main.go -kubeconfig=$(HOME)/.kube/config & 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 # Reference Guide - https://www.gnu.org/software/make/manual/make.html
 
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
-
-
+HOME = $(shell echo $$HOME)
 # list only our namespaced directories
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
@@ -76,3 +75,17 @@ dockerops:
 	# Dockerfile available in the repo root
 	sudo docker build . -f Dockerfile -t litmuschaos/chaos-exporter:ci  
 	REPONAME="litmuschaos" IMGNAME="chaos-exporter" IMGTAG="ci" ./buildscripts/push
+
+.PHONY: bdddeps
+bdddeps:
+	@echo "------------------"
+	@echo "bdd test dependencies"
+	@echo "INFO:\tverifying dependencies for bdddeps ..."
+		@echo "------------------"
+
+	@go get -u github.com/onsi/ginkgo
+	@go get -u github.com/onsi/gomega 
+	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
+	kubectl create ns litmus
+	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine.yaml
+	nohup go run cmd/exporter/main.go -kubeconfig=$(HOME)/.kube/config & 

--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,10 @@ bdddeps:
 	@echo "------------------"
 	@echo "bdd test dependencies"
 	@echo "INFO:\tverifying dependencies for bdddeps ..."
-		@echo "------------------"
+	@echo "------------------"
 
-	@go get -u github.com/onsi/ginkgo
-	@go get -u github.com/onsi/gomega 
-	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
-	kubectl create ns litmus
-	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine.yaml
+	# @go get -u github.com/onsi/ginkgo
+	# @go get -u github.com/onsi/gomega 
+	# kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
+	# kubectl create ns litmus
 	nohup go run cmd/exporter/main.go -kubeconfig=$(HOME)/.kube/config & 

--- a/dum.go
+++ b/dum.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config")
+	cmd.Stdout = os.Stdout
+	err := cmd.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Just ran subprocess %d, exiting\n", cmd.Process.Pid)
+}

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -1,0 +1,75 @@
+package bdd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestChaos(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BDD test")
+}
+
+var _ = Describe("BDD on chaos-exporter", func() {
+	// BDD case 1
+	Context("Chaos Engine failed experiments", func() {
+
+		It("should be a zero failed experiments", func() {
+			chaosengine := os.Getenv("CHAOSENGINE")
+			appNS := os.Getenv("APP_NAMESPACE")
+
+			var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+			var config *rest.Config
+			var err error
+
+			config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			By("Checking Total failed experiments")
+			expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
+			if err != nil {
+				Fail(err.Error()) // Unable to get metrics:
+			}
+
+			fmt.Println(expTotal, failTotal, passTotal, expMap)
+
+			Expect(failTotal).To(Equal(float64(0)))
+
+		})
+	})
+	// BDD case 2
+	Context("Curl the prometheus metrics", func() {
+		It("Should return prometheus metrics", func() {
+
+			resp, err := http.Get("http://127.0.0.1:8080/metrics")
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+		})
+	})
+})
+
+// deleting all unused resources
+var _ = AfterSuite(func() {
+
+	By("Deleting chaosengine CRD")
+	ceDeleteCRDs := exec.Command("kubectl", "delete", "crds", "chaosengines.litmuschaos.io").Run()
+	Expect(ceDeleteCRDs).To(BeNil())
+
+	By("Deleting namespace litmus")
+	deleteNS := exec.Command("kubectl", "delete", "ns", "litmus").Run()
+	Expect(deleteNS).To(BeNil())
+
+})

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -9,19 +9,13 @@ import (
 	"testing"
 	"time"
 
-	// chaosEngineV1alpha1 "github.com/litmuschaos/chaos-exporter/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
-	// v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
-	// chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
-	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
-
 	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
-	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
-
-	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
-	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
+	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -75,8 +69,8 @@ var _ = BeforeSuite(func() {
 
 	fmt.Println(response, err)
 
-	By("Creating ChaosEngine")
-	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config")
+	By("Building Exporter")
+	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig="+os.Getenv("HOME")+"/.kube/config")
 	cmd.Stdout = os.Stdout
 	err = cmd.Start()
 
@@ -84,10 +78,11 @@ var _ = BeforeSuite(func() {
 		log.Fatal(err)
 	}
 	Expect(err).To(BeNil())
+	time.Sleep(2000000000)
 
 	fmt.Println("process id", cmd.Process.Pid)
 
-	time.Sleep(2000000000)
+	// wait for execution of exporter
 
 })
 
@@ -122,7 +117,7 @@ var _ = Describe("BDD on chaos-exporter", func() {
 
 		})
 	})
-	// // BDD case 2
+	// BDD case 2
 	Context("Curl the prometheus metrics--", func() {
 		It("Should return prometheus metrics", func() {
 

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -1,19 +1,18 @@
-package bdd
+package main
 
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
-
-	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	// chaosEngineV1alpha1 "github.com/litmuschaos/chaos-exporter/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+
+	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/node/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -30,7 +29,7 @@ var _ = BeforeSuite(func() {
 	v1alpha1.AddToScheme(scheme.Scheme)
 	clientSet, err := clientV1alpha1.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	chaosEngine := &chaosEngineV1alpha1.ChaosEngine{
@@ -61,53 +60,58 @@ var _ = BeforeSuite(func() {
 	}
 
 	response, err := clientSet.ChaosEngines("litmus").Create(chaosEngine)
-	// res, _ := clientSet.ChaosEngines("litmus").List(metav1.ChaosEngineList{})
 	fmt.Println(response, err)
-
-	exec.Command("nohup", "go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config", "&")
+	cmd, _ := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config", "&").Output()
+	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config")
+	cmd.Stdout = os.Stdout
+	err := cmd.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Just ran subprocess %d, exiting\n", cmd.Process.Pid))
 })
 
-var _ = Describe("BDD on chaos-exporter", func() {})
+var _ = Describe("BDD on chaos-exporter", func() {
 
-// BDD case 1
-// Context("Chaos Engine failed experiments", func() {
+	// BDD case 1
+	// Context("Chaos Engine failed experiments", func() {
 
-// 	It("should be a zero failed experiments", func() {
-// 		chaosengine := os.Getenv("CHAOSENGINE")
-// 		appNS := os.Getenv("APP_NAMESPACE")
+	// 	It("should be a zero failed experiments", func() {
+	// 		chaosengine := os.Getenv("CHAOSENGINE")
+	// 		appNS := os.Getenv("APP_NAMESPACE")
 
-// 		var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
-// 		var config *rest.Config
-// 		var err error
+	// 		var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+	// 		var config *rest.Config
+	// 		var err error
 
-// 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	// 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 
-// 		if err != nil {
-// 			Fail(err.Error())
-// 		}
+	// 		if err != nil {
+	// 			Fail(err.Error())
+	// 		}
 
-// 		By("Checking Total failed experiments")
-// 		expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
-// 		if err != nil {
-// 			Fail(err.Error()) // Unable to get metrics:
-// 		}
+	// 		By("Checking Total failed experiments")
+	// 		expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
+	// 		if err != nil {
+	// 			Fail(err.Error()) // Unable to get metrics:
+	// 		}
 
-// 		fmt.Println(expTotal, failTotal, passTotal, expMap)
+	// 		fmt.Println(expTotal, failTotal, passTotal, expMap)
 
-// 		Expect(failTotal).To(Equal(float64(0)))
+	// 		Expect(failTotal).To(Equal(float64(0)))
 
-// 	})
-// })
-// // BDD case 2
-// Context("Curl the prometheus metrics", func() {
-// 	It("Should return prometheus metrics", func() {
+	// 	})
+	// })
+	// // BDD case 2
+	// Context("Curl the prometheus metrics", func() {
+	// 	It("Should return prometheus metrics", func() {
 
-// 		resp, err := http.Get("http://127.0.0.1:8080/metrics")
-// 		Expect(err).To(BeNil())
-// 		defer resp.Body.Close()
-// 	})
-// })
-// })
+	// 		resp, err := http.Get("http://127.0.0.1:8080/metrics")
+	// 		Expect(err).To(BeNil())
+	// 		defer resp.Body.Close()
+	// 	})
+	// })
+})
 
 // deleting all unused resources
 var _ = AfterSuite(func() {})

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -2,15 +2,19 @@ package bdd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"testing"
 
-	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
+	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// chaosEngineV1alpha1 "github.com/litmuschaos/chaos-exporter/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/rest"
+	"k8s.io/api/node/v1alpha1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -20,56 +24,100 @@ func TestChaos(t *testing.T) {
 	RunSpecs(t, "BDD test")
 }
 
-var _ = Describe("BDD on chaos-exporter", func() {
-	// BDD case 1
-	Context("Chaos Engine failed experiments", func() {
+var _ = BeforeSuite(func() {
+	var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	v1alpha1.AddToScheme(scheme.Scheme)
+	clientSet, err := clientV1alpha1.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
 
-		It("should be a zero failed experiments", func() {
-			chaosengine := os.Getenv("CHAOSENGINE")
-			appNS := os.Getenv("APP_NAMESPACE")
+	chaosEngine := &chaosEngineV1alpha1.ChaosEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "engine-nginx",
+			Namespace: "litmus",
+		},
+		Spec: chaosEngineV1alpha1.ChaosEngineSpec{
+			Appinfo: chaosEngineV1alpha1.ApplicationParams{
+				Appns:    "default",
+				Applabel: "app=nginx",
+			},
+			Experiments: []chaosEngineV1alpha1.ExperimentList{
+				{
+					Name: "container-kill",
+				},
+				{
+					Name: "pod-kill",
+				},
+			},
+			Schedule: chaosEngineV1alpha1.ChaosSchedule{
+				Interval:          "half-hourly",
+				ExcludedTimes:     "",
+				ExcludedDays:      "",
+				ConcurrencyPolicy: "",
+			},
+		},
+	}
 
-			var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
-			var config *rest.Config
-			var err error
+	response, err := clientSet.ChaosEngines("litmus").Create(chaosEngine)
+	// res, _ := clientSet.ChaosEngines("litmus").List(metav1.ChaosEngineList{})
+	fmt.Println(response, err)
 
-			config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-
-			if err != nil {
-				Fail(err.Error())
-			}
-
-			By("Checking Total failed experiments")
-			expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
-			if err != nil {
-				Fail(err.Error()) // Unable to get metrics:
-			}
-
-			fmt.Println(expTotal, failTotal, passTotal, expMap)
-
-			Expect(failTotal).To(Equal(float64(0)))
-
-		})
-	})
-	// BDD case 2
-	Context("Curl the prometheus metrics", func() {
-		It("Should return prometheus metrics", func() {
-
-			resp, err := http.Get("http://127.0.0.1:8080/metrics")
-			Expect(err).To(BeNil())
-			defer resp.Body.Close()
-		})
-	})
+	exec.Command("nohup", "go", "run", "../../cmd/exporter/main.go", "-kubeconfig=/home/rajdas/.kube/config", "&")
 })
+
+var _ = Describe("BDD on chaos-exporter", func() {})
+
+// BDD case 1
+// Context("Chaos Engine failed experiments", func() {
+
+// 	It("should be a zero failed experiments", func() {
+// 		chaosengine := os.Getenv("CHAOSENGINE")
+// 		appNS := os.Getenv("APP_NAMESPACE")
+
+// 		var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+// 		var config *rest.Config
+// 		var err error
+
+// 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+// 		if err != nil {
+// 			Fail(err.Error())
+// 		}
+
+// 		By("Checking Total failed experiments")
+// 		expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
+// 		if err != nil {
+// 			Fail(err.Error()) // Unable to get metrics:
+// 		}
+
+// 		fmt.Println(expTotal, failTotal, passTotal, expMap)
+
+// 		Expect(failTotal).To(Equal(float64(0)))
+
+// 	})
+// })
+// // BDD case 2
+// Context("Curl the prometheus metrics", func() {
+// 	It("Should return prometheus metrics", func() {
+
+// 		resp, err := http.Get("http://127.0.0.1:8080/metrics")
+// 		Expect(err).To(BeNil())
+// 		defer resp.Body.Close()
+// 	})
+// })
+// })
 
 // deleting all unused resources
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func() {})
 
-	By("Deleting chaosengine CRD")
-	ceDeleteCRDs := exec.Command("kubectl", "delete", "crds", "chaosengines.litmuschaos.io").Run()
-	Expect(ceDeleteCRDs).To(BeNil())
+// By("Deleting chaosengine CRD")
+// // ceDeleteCRDs := exec.Command("kubectl", "delete", "crds", "chaosengines.litmuschaos.io").Run()
+// Expect(ceDeleteCRDs).To(BeNil())
 
-	By("Deleting namespace litmus")
-	deleteNS := exec.Command("kubectl", "delete", "ns", "litmus").Run()
-	Expect(deleteNS).To(BeNil())
+// By("Deleting namespace litmus")
+// deleteNS := exec.Command("kubectl", "delete", "ns", "litmus").Run()
+// Expect(deleteNS).To(BeNil())
 
-})
+// })

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 		log.Fatal(err)
 	}
 	Expect(err).To(BeNil())
-	time.Sleep(2000000000)
+	time.Sleep(3000000000)
 
 	fmt.Println("process id", cmd.Process.Pid)
 


### PR DESCRIPTION
This PR has following this added
- [x] BDD test for check zero failed experiments
- [x] BDD test to check prometheus metrics
- [x] All BDD test are run on minikube, which is installed on travisci

Signed-off-by: Raj Babu Das raj.das@mayadata.io