### PR TITLE
include BDD tests to verify successful chaos metrics collection by exporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,46 @@
-dist: trusty
 sudo: required
-install: true
+dist: xenial
+env:
+  global:
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_HOME=$HOME
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBECONFIG=$HOME/.kube/config
+    - CHAOSENGINE=engine-nginx
+    - APP_UUID=1234
+    - APP_NAMESPACE=litmus
+services:
+  - docker
 language: go
 go:
   - 1.11.2
-env:
-  global:
-    - GOARCH=amd64
-before_install:
-  - sleep 15
-  - sudo apt-get install -y
-  - sudo apt-get install -y curl
+
+addons:
+  apt:
+    update: true
+
+before_script:
+  # Download kubectl, which is a requirement for using minikube.
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  # Download minikube.
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - mkdir -p $HOME/.kube $HOME/.minikube
+  - touch $KUBECONFIG
+  - sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0
+  - "sudo chown -R travis: /home/travis/.minikube/"
+  # Wait for Kubernetes to be up and ready.
+  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
 script:
+  # Installing Go Dependencies
   - make godeps
-  - make all
+  # bdd testing dependencies - ginkgo and gomega 
+  - make bdddeps
+  # Running all go tests
+  - make test
+
+after_success:
+  - sudo minikube delete
+  - make dockerops

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 # Reference Guide - https://www.gnu.org/software/make/manual/make.html
 
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
-
-
+HOME = $(shell echo $$HOME)
 # list only our namespaced directories
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
@@ -76,3 +75,14 @@ dockerops:
 	# Dockerfile available in the repo root
 	sudo docker build . -f Dockerfile -t litmuschaos/chaos-exporter:ci  
 	REPONAME="litmuschaos" IMGNAME="chaos-exporter" IMGTAG="ci" ./buildscripts/push
+
+.PHONY: bdddeps
+bdddeps:
+	@echo "------------------"
+	@echo "bdd test dependencies"
+	@echo "INFO:\tverifying dependencies for bdddeps ..."
+	@echo "------------------"
+	@go get -u github.com/onsi/ginkgo
+	@go get -u github.com/onsi/gomega 
+	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
+	kubectl create ns litmus

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -148,23 +148,25 @@ var _ = Describe("BDD on chaos-exporter", func() {
 
 				var k8sVersion string
 				var openEBSVersion string
-				k8sVersion, err = version.GetKubernetesVersion(config)            // getting kubernetes version
-				openEBSVersion, err = version.GetOpenebsVersion(config, "litmus") // getting openEBS Version
+				k8sVersion, _ = version.GetKubernetesVersion(config)            // getting kubernetes version
+				openEBSVersion, _ = version.GetOpenebsVersion(config, "litmus") // getting openEBS Version
+
+				var tmpStr = "{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"}"
 
 				By("Should be matched with total_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_experiment_count{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 2")))
+				Expect(string(contents)).Should(ContainSubstring(string("c_engine_experiment_count" + tmpStr + " 2")))
 
 				By("Should be matched with failed_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_failed_experiments{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 0")))
+				Expect(string(contents)).Should(ContainSubstring(string("c_engine_failed_experiments" + tmpStr + " 0")))
 
 				By("Should be matched with passed_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_passed_experiments{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 0")))
+				Expect(string(contents)).Should(ContainSubstring(string("c_engine_passed_experiments" + tmpStr + " 0")))
 
 				By("Should be matched with container_kill experiment regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_exp_container_kill{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 0")))
+				Expect(string(contents)).Should(ContainSubstring(string("c_exp_container_kill" + tmpStr + " 0")))
 
 				By("Should be matched with pod_kill experiment experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_exp_pod_kill{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 0")))
+				Expect(string(contents)).Should(ContainSubstring(string("c_exp_pod_kill" + tmpStr + " 0")))
 
 			}
 

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -145,8 +145,11 @@ var _ = Describe("BDD on chaos-exporter", func() {
 					os.Exit(1)
 				}
 				fmt.Printf("%s\n", string(contents))
-				k8sVersion, err := version.GetKubernetesVersion(config)            // getting kubernetes version
-				openEBSVersion, err := version.GetOpenebsVersion(config, "litmus") // getting openEBS Version
+
+				var k8sVersion string
+				var openEBSVersion string
+				k8sVersion, err = version.GetKubernetesVersion(config)            // getting kubernetes version
+				openEBSVersion, err = version.GetOpenebsVersion(config, "litmus") // getting openEBS Version
 
 				By("Should be matched with total_experiments regx")
 				Expect(string(contents)).Should(ContainSubstring(string("c_engine_experiment_count{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"} 2")))

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil())
 
 	// wait for execution of exporter
-	time.Sleep(3000000000)
+	time.Sleep(4000000000)
 
 	fmt.Println("process id", cmd.Process.Pid)
 

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	clientV1alpha1 "github.com/litmuschaos/chaos-exporter/pkg/clientset/v1alpha1"
+	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
+	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestChaos(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BDD test")
+}
+
+var _ = BeforeSuite(func() {
+	var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	v1alpha1.AddToScheme(scheme.Scheme)
+	clientSet, err := clientV1alpha1.NewForConfig(config)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	By("Creating ChaosEngine")
+	chaosEngine := &chaosEngineV1alpha1.ChaosEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "engine-nginx",
+			Namespace: "litmus",
+		},
+		Spec: chaosEngineV1alpha1.ChaosEngineSpec{
+			Appinfo: chaosEngineV1alpha1.ApplicationParams{
+				Appns:    "default",
+				Applabel: "app=nginx",
+			},
+			Experiments: []chaosEngineV1alpha1.ExperimentList{
+				{
+					Name: "container-kill",
+				},
+				{
+					Name: "pod-kill",
+				},
+			},
+			Schedule: chaosEngineV1alpha1.ChaosSchedule{
+				Interval:          "half-hourly",
+				ExcludedTimes:     "",
+				ExcludedDays:      "",
+				ConcurrencyPolicy: "",
+			},
+		},
+	}
+	response, err := clientSet.ChaosEngines("litmus").Create(chaosEngine)
+	Expect(err).To(BeNil())
+
+	fmt.Println(response, err)
+
+	By("Building Exporter")
+	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig="+os.Getenv("HOME")+"/.kube/config")
+	cmd.Stdout = os.Stdout
+	err = cmd.Start()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	Expect(err).To(BeNil())
+
+	// wait for execution of exporter
+	time.Sleep(3000000000)
+
+	fmt.Println("process id", cmd.Process.Pid)
+
+})
+
+var _ = Describe("BDD on chaos-exporter", func() {
+
+	// BDD case 1
+	Context("Chaos Engine failed experiments", func() {
+
+		It("should be a zero failed experiments", func() {
+			chaosengine := os.Getenv("CHAOSENGINE")
+			appNS := os.Getenv("APP_NAMESPACE")
+
+			var kubeconfig string = string(os.Getenv("HOME") + "/.kube/config")
+			var config *rest.Config
+			var err error
+
+			config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			By("Checking Total failed experiments")
+			expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
+			if err != nil {
+				Fail(err.Error()) // Unable to get metrics:
+			}
+
+			fmt.Println(expTotal, failTotal, passTotal, expMap)
+
+			Expect(failTotal).To(Equal(float64(0)))
+
+		})
+	})
+	// BDD case 2
+	Context("Curl the prometheus metrics--", func() {
+		It("Should return prometheus metrics", func() {
+
+			resp, err := http.Get("http://127.0.0.1:8080/metrics")
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+		})
+	})
+})
+
+// deleting all unused resources
+var _ = AfterSuite(func() {
+
+	By("Deleting chaosengine CRD")
+	ceDeleteCRDs := exec.Command("kubectl", "delete", "crds", "chaosengines.litmuschaos.io").Run()
+	Expect(ceDeleteCRDs).To(BeNil())
+
+	By("Deleting namespace litmus")
+	deleteNS := exec.Command("kubectl", "delete", "ns", "litmus").Run()
+	Expect(deleteNS).To(BeNil())
+
+})


### PR DESCRIPTION
This PR has following this added
- [x] BDD test for check zero failed experiments
- [x] BDD test to check prometheus metrics
- [x] All BDD test are run on minikube, which is installed on travisci

Signed-off-by: Raj Babu Das raj.das@mayadata.io