### PR TITLE
(refactor)BCH: Refactor the exporter logic a/c BCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
   - docker
 language: go
 go:
-  - 1.11.2
+  - 1.13.1
 
 addons:
   apt:
@@ -25,7 +25,7 @@ before_script:
   # Download kubectl, which is a requirement for using minikube.
   - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.35.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - curl -LO https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-linux-amd64 && sudo install minikube-linux-amd64 /usr/local/bin/minikube
   - mkdir -p $HOME/.kube $HOME/.minikube
   - touch $KUBECONFIG
   - sudo minikube start --vm-driver=none --kubernetes-version=v1.13.0

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test:
 	@echo "------------------"
 	@echo "--> Run Go Test"
 	@echo "------------------"
-	@go test ./... -v 
+	@go test ./... -v -count=1
 
 .PHONY: dockerops
 dockerops: 
@@ -84,5 +84,5 @@ bdddeps:
 	@echo "------------------"
 	@go get -u github.com/onsi/ginkgo
 	@go get -u github.com/onsi/gomega 
-	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/crds/chaosengine_crd.yaml
+	kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/chaos_crds.yaml
 	kubectl create ns litmus

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -78,14 +78,13 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 func getKubeConfig() (*rest.Config, error) {
 	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.Parse()
-	// Use in-cluster config if kubeconfig file not available
+	// Use in-cluster config if kubeconfig path is specified
 	if *kubeconfig == "" {
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return config, err
 		}
 	}
-	log.Info("using configuration from: ", *kubeconfig)
 	config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		return config, err

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -101,7 +101,7 @@ func main() {
 	}
 	exporterSpec, err := getExporterSpecs()
 	if err != nil {
-		log.Fatalf("Error: ", err)
+		log.Fatal("Error: ", err)
 	}
 	// Trigger the chaos metrics collection
 	go controller.Exporter(config, exporterSpec)

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -66,9 +66,9 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 	}
 
 	exporterSpec := controller.ExporterSpec{
-		ChaosEngine: chaosEngine,
-		AppUUID: applicationUUID,
-		AppNS: getNamespaceEnv("APP_NAMESPACE", "default"),
+		ChaosEngine:      chaosEngine,
+		AppUUID:          applicationUUID,
+		AppNS:            getNamespaceEnv("APP_NAMESPACE", "default"),
 		OpenebsNamespace: getOpenebsEnv("OPENEBS_NAMESPACE", "openebs"),
 	}
 	return exporterSpec, nil

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Declare general variables (cluster ops, error handling, misc)
-var kubeconfig string
+var kubeconfig *string
 var config *rest.Config
 var err error
 
@@ -65,7 +65,7 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 		return controller.ExporterSpec{}, fmt.Errorf("please specify correct APP_UUID & CHAOSENGINE ENVs")
 	}
 
-	exporterSpec := controller.ExporterSpec{
+	exporterSpec := controller.ExporterSpec {
 		ChaosEngine:      chaosEngine,
 		AppUUID:          applicationUUID,
 		AppNS:            getNamespaceEnv("APP_NAMESPACE", "default"),
@@ -76,16 +76,17 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 
 // getKubeConfig setup the config for access cluster resource
 func getKubeConfig() (*rest.Config, error) {
+	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.Parse()
 	// Use in-cluster config if kubeconfig file not available
-	if kubeconfig == "" {
+	if *kubeconfig == "" {
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return config, err
 		}
 	}
-	log.Info("using configuration from: ", kubeconfig)
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
-	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	log.Info("using configuration from: ", *kubeconfig)
+	config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		return config, err
 	}
@@ -93,7 +94,6 @@ func getKubeConfig() (*rest.Config, error) {
 }
 
 func main() {
-	flag.Parse()
 	// Setting up kubeconfig
 	config, err := getKubeConfig()
 	if err != nil {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -21,68 +21,23 @@
 package main
 
 import (
-	"os"
-	"time"
-
-	//"fmt"
 	"flag"
-	"net/http"
-	"strings"
-
 	log "github.com/Sirupsen/logrus"
-	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
-	"github.com/litmuschaos/chaos-exporter/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"net/http"
+	"os"
+
+	"github.com/litmuschaos/chaos-exporter/pkg/version"
+	"github.com/litmuschaos/chaos-exporter/controller"
 )
 
 // Declare general variables (cluster ops, error handling, misc)
 var kubeconfig string
 var config *rest.Config
 var err error
-var registeredResultMetrics []string
-
-// Declare the fixed chaos metrics. Dynamic (testStatus) metrics are defined in metrics()
-var (
-	experimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "c",
-		Subsystem: "engine",
-		Name:      "experiment_count",
-		Help:      "Total number of experiments executed by the chaos engine",
-	},
-		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
-	)
-
-	passedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "c",
-		Subsystem: "engine",
-		Name:      "passed_experiments",
-		Help:      "Total number of passed experiments",
-	},
-		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
-	)
-
-	failedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "c",
-		Subsystem: "engine",
-		Name:      "failed_experiments",
-		Help:      "Total number of failed experiments",
-	},
-		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
-	)
-)
-
-// contains checks if the a string is already part of a list of strings
-func contains(l []string, e string) bool {
-	for _, i := range l {
-		if i == e {
-			return true
-		}
-	}
-	return false
-}
 
 // getnamespaceEnv checks whether an ENV variable has been set, else sets a default value
 func getNamespaceEnv(key, fallback string) string {
@@ -92,57 +47,12 @@ func getNamespaceEnv(key, fallback string) string {
 	return fallback
 }
 
-// get
+// get OpenEBS related environments
 func getOpenebsEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
 	return fallback
-}
-
-// exporter continuously collects the chaos metrics for a given chaosengine
-func exporter(cfg *rest.Config, chaosEngine string, appUUID string, appNS string, kubernetesVersion string, openebsVersion string) {
-
-	for {
-		// Get the chaos metrics for the specified chaosengine
-		expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(cfg, chaosEngine, appNS)
-		if err != nil {
-			//panic(err.Error())
-			log.Fatal("Unable to get metrics: ", err.Error())
-		}
-
-		// Define, register & set the dynamically obtained chaos metrics (experiment state)
-		for index, verdict := range expMap {
-			sanitizedExpName := strings.Replace(index, "-", "_", -1)
-			var (
-				tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-					Namespace: "c",
-					Subsystem: "exp",
-					Name:      sanitizedExpName,
-					Help:      "",
-				},
-					[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
-				)
-			)
-
-			if contains(registeredResultMetrics, sanitizedExpName) {
-				prometheus.Unregister(tmpExp)
-				prometheus.MustRegister(tmpExp)
-				tmpExp.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
-			} else {
-				prometheus.MustRegister(tmpExp)
-				tmpExp.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
-				registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
-			}
-
-			// Set the fixed chaos metrics
-			experimentsTotal.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(expTotal)
-			passedExperiments.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(passTotal)
-			failedExperiments.WithLabelValues(appUUID, chaosEngine, kubernetesVersion, openebsVersion).Set(failTotal)
-		}
-
-		time.Sleep(1000 * time.Millisecond)
-	}
 }
 
 func main() {
@@ -189,12 +99,19 @@ func main() {
 		//openebsVersion = "N/A"
 	}
 	// Register the fixed (count) chaos metrics
-	prometheus.MustRegister(experimentsTotal)
-	prometheus.MustRegister(passedExperiments)
-	prometheus.MustRegister(failedExperiments)
+	prometheus.MustRegister(controller.ExperimentsTotal)
+	prometheus.MustRegister(controller.PassedExperiments)
+	prometheus.MustRegister(controller.FailedExperiments)
 
+	exporterSpec := controller.ExporterSpec{
+		ChaosEngine: chaosEngine,
+		AppUUID: applicationUUID,
+		AppNS: appNamespace,
+		KubernetesVersion: kubernetesVersion,
+		OpenebsVersion: openebsVersion,
+	}
 	// Trigger the chaos metrics collection
-	go exporter(config, chaosEngine, applicationUUID, appNamespace, kubernetesVersion, openebsVersion)
+	go controller.Exporter(config, exporterSpec)
 
 	//This section will start the HTTP server and expose
 	//any metrics on the /metrics endpoint.

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -38,7 +38,7 @@ var kubeconfig *string
 var config *rest.Config
 var err error
 
-// getnamespaceEnv checks whether an ENV variable has been set, else sets a default value
+// getNamespaceEnv checks whether an ENV variable has been set, else sets a default value
 func getNamespaceEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
@@ -65,7 +65,7 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 		return controller.ExporterSpec{}, fmt.Errorf("please specify correct APP_UUID & CHAOSENGINE ENVs")
 	}
 
-	exporterSpec := controller.ExporterSpec {
+	exporterSpec := controller.ExporterSpec{
 		ChaosEngine:      chaosEngine,
 		AppUUID:          applicationUUID,
 		AppNS:            getNamespaceEnv("APP_NAMESPACE", "default"),

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"k8s.io/client-go/kubernetes"
 	"strings"
 	"time"
 
@@ -13,23 +14,24 @@ import (
 
 // Exporter continuously collects the chaos metrics for a given chaosengine
 func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
-
+	k8sClientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Info("Unable to create the kubernetes ClientSet")
+	}
 	// Register the fixed (count) chaos metrics
 	prometheus.MustRegister(ExperimentsTotal)
 	prometheus.MustRegister(PassedExperiments)
 	prometheus.MustRegister(FailedExperiments)
 
 	// This function gets the kubernetes version
-	kubernetesVersion, err := version.GetKubernetesVersion(config)
+	kubernetesVersion, err := version.GetKubernetesVersion(k8sClientSet)
 	if err != nil {
 		log.Info("Unable to get Kubernetes Version : ", err)
-		//kubernetesVersion = "N/A"
 	}
 	// This function gets the openebs version
-	openebsVersion, err := version.GetOpenebsVersion(config, exporterSpec.OpenebsNamespace)
+	openebsVersion, err := version.GetOpenebsVersion(k8sClientSet, exporterSpec.OpenebsNamespace)
 	if err != nil {
 		log.Info("Unable to get OpenEBS Version : ", err)
-		//openebsVersion = "N/A"
 	}
 
 	for {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
+	clientV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned"
 
 	"github.com/litmuschaos/chaos-exporter/pkg/version"
 )
@@ -17,6 +18,10 @@ func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
 	k8sClientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Info("Unable to create the kubernetes ClientSet")
+	}
+	litmusClientSet, err := clientV1alpha1.NewForConfig(config)
+	if err != nil {
+		log.Info("Unable to create the litmus ClientSet")
 	}
 	// Register the fixed (count) chaos metrics
 	prometheus.MustRegister(ExperimentsTotal)
@@ -36,7 +41,7 @@ func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
 
 	for {
 		// Get the chaos metrics for the specified chaosengine
-		expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(config, exporterSpec)
+		expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(litmusClientSet, exporterSpec)
 		if err != nil {
 			log.Error("Unable to get metrics: ", err.Error())
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -25,7 +25,8 @@ func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
 	if err != nil {
 		log.Error(err)
 	}
-
+	// Register the fixed (count) chaos metrics
+	registerFixedMetrics()
 	spec := ExporterConfig{Spec: exporterSpec, version: versions}
 	for {
 		generateChaosMetrics(spec, litmusClientSet)
@@ -71,10 +72,6 @@ func contains(l []string, e string) bool {
 }
 
 func generateChaosMetrics(exporterConfig ExporterConfig, litmusClientSet *clientV1alpha1.Clientset) {
-	// Register the fixed (count) chaos metrics
-	prometheus.MustRegister(ExperimentsTotal)
-	prometheus.MustRegister(PassedExperiments)
-	prometheus.MustRegister(FailedExperiments)
 
 	// Get the chaos metrics for the specified chaosengine
 	expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(litmusClientSet, exporterConfig.Spec)
@@ -120,4 +117,10 @@ func setFixedChaosMetrics(chaosMetricsSpec ChaosMetricsSpec, exporterConfig Expo
 	ExperimentsTotal.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(chaosMetricsSpec.ExpTotal)
 	PassedExperiments.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(chaosMetricsSpec.PassTotal)
 	FailedExperiments.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(chaosMetricsSpec.FailTotal)
+}
+
+func registerFixedMetrics() {
+	prometheus.MustRegister(ExperimentsTotal)
+	prometheus.MustRegister(PassedExperiments)
+	prometheus.MustRegister(FailedExperiments)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -80,7 +80,7 @@ func generateChaosMetrics(exporterConfig ExporterConfig, litmusClientSet *client
 	}
 
 	// Define, register & set the dynamically obtained chaos metrics (experiment state)
-	chaosMetricsSpec := ChaosMetricsSpec{ExpTotal: expTotal, PassTotal: passTotal, FailTotal: failTotal, ExperimentList: expMap,}
+	chaosMetricsSpec := ChaosMetricsSpec{ExpTotal: expTotal, PassTotal: passTotal, FailTotal: failTotal, ExperimentList: expMap}
 	defineChaosMetrics(chaosMetricsSpec, exporterConfig)
 	time.Sleep(1000 * time.Millisecond)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,83 +1,63 @@
 package controller
 
 import (
-	"k8s.io/client-go/kubernetes"
+	"fmt"
 	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/client-go/rest"
 	clientV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/litmuschaos/chaos-exporter/pkg/version"
 )
 
 // Exporter continuously collects the chaos metrics for a given chaosengine
 func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
+	k8sClientSet, litmusClientSet, err := generateClientSets(config)
+	if err != nil {
+		log.Error(err)
+	}
+
+	versions, err := getVersion(k8sClientSet, exporterSpec)
+	if err != nil {
+		log.Error(err)
+	}
+
+	spec := ExporterConfig{ Spec: exporterSpec, version: versions}
+	for {
+		generateChaosMetrics(spec, litmusClientSet)
+	}
+}
+
+func getVersion(clientSet *kubernetes.Clientset, exporterSpec ExporterSpec) (Version, error) {
+	var v Version
+	var err error
+	v.KubernetesVersion, err = version.GetKubernetesVersion(clientSet)
+	if err != nil {
+		return v, fmt.Errorf("unable to get Kubernetes Version %s: ", err)
+	}
+	// This function gets the openebs version
+	v.OpenebsVersion, err = version.GetOpenebsVersion(clientSet, exporterSpec.OpenebsNamespace)
+	if err != nil {
+		return v , fmt.Errorf("unable to get OpenEBS Version %s: ", err)
+	}
+	return v, nil
+}
+
+// generateClientSets will generate clientSet for kubernetes and litmus
+func generateClientSets(config *rest.Config) (*kubernetes.Clientset, *clientV1alpha1.Clientset, error){
 	k8sClientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Info("Unable to create the kubernetes ClientSet")
+		return nil, nil, fmt.Errorf("unable to generate kubernetes clientSet %s: ", err)
 	}
 	litmusClientSet, err := clientV1alpha1.NewForConfig(config)
 	if err != nil {
-		log.Info("Unable to create the litmus ClientSet")
+		return nil, nil, fmt.Errorf("unable to generate litmus clientSet %s: ", err)
 	}
-	// Register the fixed (count) chaos metrics
-	prometheus.MustRegister(ExperimentsTotal)
-	prometheus.MustRegister(PassedExperiments)
-	prometheus.MustRegister(FailedExperiments)
-
-	// This function gets the kubernetes version
-	kubernetesVersion, err := version.GetKubernetesVersion(k8sClientSet)
-	if err != nil {
-		log.Info("Unable to get Kubernetes Version : ", err)
-	}
-	// This function gets the openebs version
-	openebsVersion, err := version.GetOpenebsVersion(k8sClientSet, exporterSpec.OpenebsNamespace)
-	if err != nil {
-		log.Info("Unable to get OpenEBS Version : ", err)
-	}
-
-	for {
-		// Get the chaos metrics for the specified chaosengine
-		expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(litmusClientSet, exporterSpec)
-		if err != nil {
-			log.Error("Unable to get metrics: ", err.Error())
-		}
-
-		// Define, register & set the dynamically obtained chaos metrics (experiment state)
-		for index, verdict := range expMap {
-			sanitizedExpName := strings.Replace(index, "-", "_", -1)
-			var (
-				tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-					Namespace: "c",
-					Subsystem: "exp",
-					Name:      sanitizedExpName,
-					Help:      "",
-				},
-					[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
-				)
-			)
-
-			if contains(registeredResultMetrics, sanitizedExpName) {
-				prometheus.Unregister(tmpExp)
-				prometheus.MustRegister(tmpExp)
-				tmpExp.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
-			} else {
-				prometheus.MustRegister(tmpExp)
-				tmpExp.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, kubernetesVersion, openebsVersion).Set(verdict)
-				registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
-			}
-
-			// Set the fixed chaos metrics
-			ExperimentsTotal.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, kubernetesVersion, openebsVersion).Set(expTotal)
-			PassedExperiments.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, kubernetesVersion, openebsVersion).Set(passTotal)
-			FailedExperiments.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, kubernetesVersion, openebsVersion).Set(failTotal)
-		}
-
-		time.Sleep(1000 * time.Millisecond)
-	}
+	return k8sClientSet, litmusClientSet, nil
 }
 
 // contains checks if the a string is already part of a list of strings
@@ -88,4 +68,48 @@ func contains(l []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func generateChaosMetrics(exporterConfig ExporterConfig, litmusClientSet *clientV1alpha1.Clientset) {
+	// Register the fixed (count) chaos metrics
+	prometheus.MustRegister(ExperimentsTotal)
+	prometheus.MustRegister(PassedExperiments)
+	prometheus.MustRegister(FailedExperiments)
+
+	// Get the chaos metrics for the specified chaosengine
+	expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(litmusClientSet, exporterConfig.Spec)
+	if err != nil {
+		log.Error("Unable to get metrics: ", err.Error())
+	}
+
+	// Define, register & set the dynamically obtained chaos metrics (experiment state)
+	for index, verdict := range expMap {
+		sanitizedExpName := strings.Replace(index, "-", "_", -1)
+		var (
+			tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "c",
+				Subsystem: "exp",
+				Name:      sanitizedExpName,
+				Help:      "",
+			},
+				[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+			)
+		)
+
+		if contains(registeredResultMetrics, sanitizedExpName) {
+			prometheus.Unregister(tmpExp)
+			prometheus.MustRegister(tmpExp)
+			tmpExp.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(verdict)
+		} else {
+			prometheus.MustRegister(tmpExp)
+			tmpExp.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(verdict)
+			registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
+		}
+
+		// Set the fixed chaos metrics
+		ExperimentsTotal.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(expTotal)
+		PassedExperiments.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(passTotal)
+		FailedExperiments.WithLabelValues(exporterConfig.Spec.AppUUID, exporterConfig.Spec.ChaosEngine, exporterConfig.version.KubernetesVersion, exporterConfig.version.OpenebsVersion).Set(failTotal)
+	}
+	time.Sleep(1000 * time.Millisecond)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,0 +1,63 @@
+package controller
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
+	"strings"
+	"time"
+	)
+
+// Exporter continuously collects the chaos metrics for a given chaosengine
+func Exporter(config *rest.Config, exporterSpec ExporterSpec) {
+
+	for {
+		// Get the chaos metrics for the specified chaosengine
+		expTotal, passTotal, failTotal, expMap, err := GetLitmusChaosMetrics(config, exporterSpec)
+		if err != nil {
+			log.Error("Unable to get metrics: ", err.Error())
+		}
+
+		// Define, register & set the dynamically obtained chaos metrics (experiment state)
+		for index, verdict := range expMap {
+			sanitizedExpName := strings.Replace(index, "-", "_", -1)
+			var (
+				tmpExp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: "c",
+					Subsystem: "exp",
+					Name:      sanitizedExpName,
+					Help:      "",
+				},
+					[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+				)
+			)
+
+			if contains(registeredResultMetrics, sanitizedExpName) {
+				prometheus.Unregister(tmpExp)
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, exporterSpec.KubernetesVersion, exporterSpec.OpenebsVersion).Set(verdict)
+			} else {
+				prometheus.MustRegister(tmpExp)
+				tmpExp.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, exporterSpec.KubernetesVersion, exporterSpec.OpenebsVersion).Set(verdict)
+				registeredResultMetrics = append(registeredResultMetrics, sanitizedExpName)
+			}
+
+			// Set the fixed chaos metrics
+			ExperimentsTotal.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, exporterSpec.KubernetesVersion, exporterSpec.OpenebsVersion).Set(expTotal)
+			PassedExperiments.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, exporterSpec.KubernetesVersion, exporterSpec.OpenebsVersion).Set(passTotal)
+			FailedExperiments.WithLabelValues(exporterSpec.AppUUID, exporterSpec.ChaosEngine, exporterSpec.KubernetesVersion, exporterSpec.OpenebsVersion).Set(failTotal)
+		}
+
+		time.Sleep(1000 * time.Millisecond)
+	}
+}
+
+// contains checks if the a string is already part of a list of strings
+func contains(l []string, e string) bool {
+	for _, i := range l {
+		if i == e {
+			return true
+		}
+	}
+	return false
+}

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -15,26 +15,30 @@ import (
 var chaosExperimentList []string
 
 // Holds a map of experiment: result
-var chaosresultmap map[string]string
-
-// Holds a map of experiment: numeric representation(result)
-var statusmap map[string]float64
+var chaosResultMap map[string]string
 
 // Holds a lookup of result: numericValue
-var numericstatus = map[string]float64{
+var numericStatus = map[string]float64{
 	"not-executed": 0,
 	"running":      1,
 	"fail":         2,
 	"pass":         3,
 }
 
+// ChaosExpResult...
+type ChaosExpResult struct {
+	TotalExpCount  float64
+	TotalPassedExp float64
+	TotalFailedExp float64
+	StatusMap      map[string]float64
+}
+
 // Utility fn to return numeric value for a result
-func statusConv(expstatus string) (numeric float64) {
-	if numeric, ok := numericstatus[expstatus]; ok {
+func statusConversion(expStatus string) (numeric float64) {
+	if numeric, ok := numericStatus[expStatus]; ok {
 		return numeric
 	}
-	//return 127
-	return 0
+	return numericStatus["not-executed"]
 }
 
 // GetLitmusChaosMetrics returns chaos metrics for a given chaosengine
@@ -54,43 +58,41 @@ func GetLitmusChaosMetrics(config *rest.Config, exporterSpec ExporterSpec) (floa
 		chaosExperimentList = append(chaosExperimentList, element.Name)
 	}
 
-	// Set default values on the chaosresult map before populating w/ actual values
+	// Set default values on the chaosResult map before populating w/ actual values
 
 	for _, test := range chaosExperimentList {
-		chaosresultname := fmt.Sprintf("%s-%s", exporterSpec.ChaosEngine, test)
-		testresultdump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(exporterSpec.AppNS).Get(chaosresultname, metav1.GetOptions{})
+		chaosResultName := fmt.Sprintf("%s-%s", exporterSpec.ChaosEngine, test)
+		testResultDump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(exporterSpec.AppNS).Get(chaosResultName, metav1.GetOptions{})
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				// lack of result cr indicates experiment not executed
-				chaosresultmap[test] = "not-executed"
+				chaosResultMap[test] = "not-executed"
 			}
-			//return 0, 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
-		result := testresultdump.Spec.ExperimentStatus.Verdict
-		//chaosresultmap[chaosresultname] = result
-		chaosresultmap[test] = result
+		result := testResultDump.Spec.ExperimentStatus.Verdict
+		chaosResultMap[test] = result
 	}
 
-	pcount, fcount := 0, 0
-	for _, verdict := range chaosresultmap {
-		if verdict == "pass" {
-			pcount++
-		} else if verdict == "fail" {
-			fcount++
-		}
-	}
-
-	//Map verdict to numerical values {0-notstarted, 1-running, 2-fail, 3-pass}
-	statusmap := make(map[string]float64)
-	for index, status := range chaosresultmap {
-		val := statusConv(status)
-		statusmap[index] = val
-	}
-	fmt.Printf("%+v\n", statusmap)
-
-	totalPassedExp := float64(pcount)
-	totalFailedExp := float64(fcount)
+	chaosResult := calculateChaosResult(chaosResultMap)
+	fmt.Printf("%+v\n", chaosResult.StatusMap)
 	totalExpCount := float64(len(engine.Spec.Experiments))
 
-	return totalExpCount, totalPassedExp, totalFailedExp, statusmap, nil
+	return totalExpCount, chaosResult.TotalPassedExp, chaosResult.TotalFailedExp, chaosResult.StatusMap, nil
+}
+
+// calculateChaosResult will calculate the number of pass and failed experiments
+func calculateChaosResult(chaosResult map[string]string) ChaosExpResult {
+	var cr ChaosExpResult
+
+	for index, status := range chaosResult {
+		if status == "pass" {
+			cr.TotalPassedExp++
+		} else if status == "fail" {
+			cr.TotalFailedExp++
+		}
+		cr.StatusMap[index] = statusConversion(status)
+	}
+
+	return cr
 }

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -25,7 +25,7 @@ var numericStatus = map[string]float64{
 	"pass":         3,
 }
 
-// ChaosExpResult...
+// ChaosExpResult contains the structure of Chaos Result
 type ChaosExpResult struct {
 	TotalExpCount  float64
 	TotalPassedExp float64

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -53,7 +53,7 @@ func GetLitmusChaosMetrics(clientSet *clientV1alpha1.Clientset, exporterSpec Exp
 	}
 
 	// Set default values on the chaosResult map before populating w/ actual values
-	spec := ChaosResultSpec{ ExporterSpec: exporterSpec, ChaosExperimentList: chaosExperimentList }
+	spec := ChaosResultSpec{ExporterSpec: exporterSpec, ChaosExperimentList: chaosExperimentList}
 	setChaosResultValue(clientSet, spec)
 
 	chaosResult := calculateChaosResult(chaosResultMap)

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -43,7 +43,6 @@ func statusConversion(expStatus string) (numeric float64) {
 
 // GetLitmusChaosMetrics returns chaos metrics for a given chaosengine
 func GetLitmusChaosMetrics(clientSet *clientV1alpha1.Clientset, exporterSpec ExporterSpec) (float64, float64, float64, map[string]float64, error) {
-
 	engine, err := clientSet.LitmuschaosV1alpha1().ChaosEngines(exporterSpec.AppNS).Get(exporterSpec.ChaosEngine, metav1.GetOptions{})
 	if err != nil {
 		return 0, 0, 0, nil, err
@@ -63,6 +62,7 @@ func GetLitmusChaosMetrics(clientSet *clientV1alpha1.Clientset, exporterSpec Exp
 	return totalExpCount, chaosResult.TotalPassedExp, chaosResult.TotalFailedExp, chaosResult.StatusMap, nil
 }
 
+// setChaosResultValue will populate the default value of chaos result
 func setChaosResultValue(clientSet *clientV1alpha1.Clientset, chaosExperimentList []string, exporterSpec ExporterSpec) {
 	for _, test := range chaosExperimentList {
 		chaosResultName := fmt.Sprintf("%s-%s", exporterSpec.ChaosEngine, test)

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -53,7 +53,8 @@ func GetLitmusChaosMetrics(clientSet *clientV1alpha1.Clientset, exporterSpec Exp
 	}
 
 	// Set default values on the chaosResult map before populating w/ actual values
-	setChaosResultValue(clientSet, chaosExperimentList, exporterSpec)
+	spec := ChaosResultSpec{ ExporterSpec: exporterSpec, ChaosExperimentList: chaosExperimentList }
+	setChaosResultValue(clientSet, spec)
 
 	chaosResult := calculateChaosResult(chaosResultMap)
 	fmt.Printf("%+v\n", chaosResult.StatusMap)
@@ -63,10 +64,10 @@ func GetLitmusChaosMetrics(clientSet *clientV1alpha1.Clientset, exporterSpec Exp
 }
 
 // setChaosResultValue will populate the default value of chaos result
-func setChaosResultValue(clientSet *clientV1alpha1.Clientset, chaosExperimentList []string, exporterSpec ExporterSpec) {
-	for _, test := range chaosExperimentList {
-		chaosResultName := fmt.Sprintf("%s-%s", exporterSpec.ChaosEngine, test)
-		testResultDump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(exporterSpec.AppNS).Get(chaosResultName, metav1.GetOptions{})
+func setChaosResultValue(clientSet *clientV1alpha1.Clientset, chaosResultSpec ChaosResultSpec) {
+	for _, test := range chaosResultSpec.ChaosExperimentList {
+		chaosResultName := fmt.Sprintf("%s-%s", chaosResultSpec.ExporterSpec.ChaosEngine, test)
+		testResultDump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(chaosResultSpec.ExporterSpec.AppNS).Get(chaosResultName, metav1.GetOptions{})
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				// lack of result cr indicates experiment not executed

--- a/controller/scrape.go
+++ b/controller/scrape.go
@@ -1,4 +1,4 @@
-package chaosmetrics
+package controller
 
 import (
 	"fmt"
@@ -28,9 +28,6 @@ var numericstatus = map[string]float64{
 	"pass":         3,
 }
 
-// Holds Error type
-var err error
-
 // Utility fn to return numeric value for a result
 func statusConv(expstatus string) (numeric float64) {
 	if numeric, ok := numericstatus[expstatus]; ok {
@@ -41,14 +38,14 @@ func statusConv(expstatus string) (numeric float64) {
 }
 
 // GetLitmusChaosMetrics returns chaos metrics for a given chaosengine
-func GetLitmusChaosMetrics(cfg *rest.Config, cEngine string, ns string) (totalExpCount, totalPassedExp, totalFailedExp float64, rMap map[string]float64, err error) {
+func GetLitmusChaosMetrics(cfg *rest.Config, exporterSpec ExporterSpec) (totalExpCount, totalPassedExp, totalFailedExp float64, rMap map[string]float64, err error) {
 
 	clientSet, err := clientV1alpha1.NewForConfig(cfg)
 	if err != nil {
 		return 0, 0, 0, nil, err
 	}
 
-	engine, err := clientSet.LitmuschaosV1alpha1().ChaosEngines(ns).Get(cEngine, metav1.GetOptions{})
+	engine, err := clientSet.LitmuschaosV1alpha1().ChaosEngines(exporterSpec.AppNS).Get(exporterSpec.ChaosEngine, metav1.GetOptions{})
 	if err != nil {
 		return 0, 0, 0, nil, err
 	}
@@ -69,8 +66,8 @@ func GetLitmusChaosMetrics(cfg *rest.Config, cEngine string, ns string) (totalEx
 	//for _, test:= range chaosexperimentlist{
 
 	for _, test := range chaosexperimentlist {
-		chaosresultname := fmt.Sprintf("%s-%s", cEngine, test)
-		testresultdump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(ns).Get(chaosresultname, metav1.GetOptions{})
+		chaosresultname := fmt.Sprintf("%s-%s", exporterSpec.ChaosEngine, test)
+		testresultdump, err := clientSet.LitmuschaosV1alpha1().ChaosResults(exporterSpec.AppNS).Get(chaosresultname, metav1.GetOptions{})
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				// lack of result cr indicates experiment not executed

--- a/controller/types.go
+++ b/controller/types.go
@@ -64,10 +64,10 @@ type ChaosResultSpec struct {
 
 // ChaosMetricsSpec contains the specs related to chaos metrics
 type ChaosMetricsSpec struct {
-	ExpTotal  float64
-	PassTotal float64
-	FailTotal float64
-	ExperimentList    map[string]float64
+	ExpTotal       float64
+	PassTotal      float64
+	FailTotal      float64
+	ExperimentList map[string]float64
 }
 
 // ChaosExpResult contains the structure of Chaos Result

--- a/controller/types.go
+++ b/controller/types.go
@@ -52,6 +52,12 @@ type Version struct {
 
 // ExporterConfig contains the config for exporter function
 type ExporterConfig struct {
-	Spec ExporterSpec
+	Spec    ExporterSpec
 	version Version
+}
+
+// ChaosResultSpec contains the specs related to generate teh chaos result
+type ChaosResultSpec struct {
+	ExporterSpec        ExporterSpec
+	ChaosExperimentList []string
 }

--- a/controller/types.go
+++ b/controller/types.go
@@ -69,3 +69,10 @@ type ChaosMetricsSpec struct {
 	FailTotal float64
 	ExperimentList    map[string]float64
 }
+
+// ChaosExpResult contains the structure of Chaos Result
+type ChaosExpResult struct {
+	TotalExpCount  float64
+	TotalPassedExp float64
+	TotalFailedExp float64
+}

--- a/controller/types.go
+++ b/controller/types.go
@@ -41,6 +41,5 @@ type ExporterSpec struct {
 	ChaosEngine string
 	AppUUID string
 	AppNS string
-	KubernetesVersion string
-	OpenebsVersion string
+	OpenebsNamespace string
 }

--- a/controller/types.go
+++ b/controller/types.go
@@ -44,11 +44,13 @@ type ExporterSpec struct {
 	OpenebsNamespace string
 }
 
+// Version contains the version related information
 type Version struct {
 	KubernetesVersion string
 	OpenebsVersion    string
 }
 
+// ExporterConfig contains the config for exporter function
 type ExporterConfig struct {
 	Spec ExporterSpec
 	version Version

--- a/controller/types.go
+++ b/controller/types.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	)
+
+var registeredResultMetrics []string
+
+// Declare the fixed chaos metrics. Dynamic (testStatus) metrics are defined in metrics()
+var (
+	ExperimentsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "experiment_count",
+		Help:      "Total number of experiments executed by the chaos engine",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
+
+	PassedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "passed_experiments",
+		Help:      "Total number of passed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
+
+	FailedExperiments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "c",
+		Subsystem: "engine",
+		Name:      "failed_experiments",
+		Help:      "Total number of failed experiments",
+	},
+		[]string{"app_uid", "engine_name", "kubernetes_version", "openebs_version"},
+	)
+)
+
+// ExporterSpec contains the exporter related specs
+type ExporterSpec struct {
+	ChaosEngine string
+	AppUUID string
+	AppNS string
+	KubernetesVersion string
+	OpenebsVersion string
+}

--- a/controller/types.go
+++ b/controller/types.go
@@ -61,3 +61,11 @@ type ChaosResultSpec struct {
 	ExporterSpec        ExporterSpec
 	ChaosExperimentList []string
 }
+
+// ChaosMetricsSpec contains the specs related to chaos metrics
+type ChaosMetricsSpec struct {
+	ExpTotal  float64
+	PassTotal float64
+	FailTotal float64
+	ExperimentList    map[string]float64
+}

--- a/controller/types.go
+++ b/controller/types.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	)
+)
 
 var registeredResultMetrics []string
 
@@ -38,8 +38,18 @@ var (
 
 // ExporterSpec contains the exporter related specs
 type ExporterSpec struct {
-	ChaosEngine string
-	AppUUID string
-	AppNS string
+	ChaosEngine      string
+	AppUUID          string
+	AppNS            string
 	OpenebsNamespace string
+}
+
+type Version struct {
+	KubernetesVersion string
+	OpenebsVersion    string
+}
+
+type ExporterConfig struct {
+	Spec ExporterSpec
+	version Version
 }

--- a/pkg/version/kubernetesVersion.go
+++ b/pkg/version/kubernetesVersion.go
@@ -2,19 +2,12 @@ package version
 
 import (
 	"fmt"
-
-	discovery "k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
 )
 
 // GetKubernetesVersion function gets kubernetes Version
-func GetKubernetesVersion(cfg *rest.Config) (string, error) {
+func GetKubernetesVersion(clientSet *kubernetes.Clientset) (string, error) {
 	// function to get Kubernetes Version
-	clientSet, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		fmt.Println("Unable to create the required ClientSet")
-		return "N/A", err
-	}
 	version, err := clientSet.ServerVersion()
 	if err != nil {
 		fmt.Println("ClientSet is unable to communicate with the kubernetes cluster")

--- a/pkg/version/openebsVersion.go
+++ b/pkg/version/openebsVersion.go
@@ -11,7 +11,7 @@ var openebsLabel = "openebs.io/component-name=maya-apiserver"
 
 // GetOpenebsVersion function fetchs the OpenEBS version
 func GetOpenebsVersion(clientSet *kubernetes.Clientset, namespace string) (string, error) {
-	podList, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: openebsLabel, Limit:1})
+	podList, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: openebsLabel, Limit: 1})
 	if err != nil {
 		return "", fmt.Errorf("unable to find openebs/maya api-server %s", err)
 	}

--- a/pkg/version/openebsVersion.go
+++ b/pkg/version/openebsVersion.go
@@ -1,37 +1,25 @@
 package version
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var openebsVersion string
+var openebsLabel = "openebs.io/component-name=maya-apiserver"
 
 // GetOpenebsVersion function fetchs the OpenEBS version
-func GetOpenebsVersion(cfg *rest.Config, namespace string) (string, error) {
-	clientSet, err := kubernetes.NewForConfig(cfg)
+func GetOpenebsVersion(clientSet *kubernetes.Clientset, namespace string) (string, error) {
+	podList, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: openebsLabel, Limit:1})
 	if err != nil {
-		log.Info("Unable to create the required ClientSet")
-		return "N/A", err
+		return "", fmt.Errorf("unable to find openebs/maya api-server %s", err)
 	}
-	list, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: "openebs.io/component-name=maya-apiserver",
-		Limit:         1,
-	})
-	if err != nil {
-		log.Info("Unable to find openebs / maya api-server")
-		return "N/A", err
+	if len(podList.Items) == 0 {
+		return "", fmt.Errorf("no resources with labels 'openebs.io/component-name=maya-apiserver' found")
 	}
-	if len(list.Items) == 0 {
-		log.Info("No resources with labels 'openebs.io/component-name=maya-apiserver' found")
-		return "N/A", err
-	}
-	for _, v := range list.Items {
+	for _, v := range podList.Items {
 		openebsVersion = v.GetLabels()["openebs.io/version"]
 	}
-
 	return openebsVersion, err
-
 }

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/litmuschaos/chaos-exporter/pkg/chaosmetrics"
+	"github.com/litmuschaos/chaos-exporter/controller"
 	version "github.com/litmuschaos/chaos-exporter/pkg/version"
 
 	. "github.com/onsi/ginkgo"
@@ -24,11 +24,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var kubeconfig = string(os.Getenv("HOME") + "/.kube/config")
+var kubeconfig = os.Getenv("HOME") + "/.kube/config"
 var config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-var chaosengine = os.Getenv("CHAOSENGINE")
-var appNS = os.Getenv("APP_NAMESPACE")
 var appUUID = os.Getenv("APP_UUID")
+
+var exporterSpec = controller.ExporterSpec{
+	AppNS: os.Getenv("APP_NAMESPACE"),
+	ChaosEngine: os.Getenv("CHAOSENGINE"),
+}
 
 func TestChaos(t *testing.T) {
 
@@ -103,7 +106,7 @@ var _ = Describe("BDD on chaos-exporter", func() {
 			}
 
 			By("Checking experiments metrics")
-			expTotal, passTotal, failTotal, expMap, err := chaosmetrics.GetLitmusChaosMetrics(config, chaosengine, appNS)
+			expTotal, passTotal, failTotal, expMap, err := controller.GetLitmusChaosMetrics(config, exporterSpec)
 			if err != nil {
 				Fail(err.Error()) // Unable to get metrics:
 			}

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes"
 	"log"
 	"net/http"
 	"os"
@@ -11,18 +10,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/litmuschaos/chaos-exporter/controller"
-	version "github.com/litmuschaos/chaos-exporter/pkg/version"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	v1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis"
 	chaosEngineV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	clientV1alpha1 "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/litmuschaos/chaos-exporter/controller"
+	"github.com/litmuschaos/chaos-exporter/pkg/version"
 )
 
 var kubeconfig = os.Getenv("HOME") + "/.kube/config"
@@ -30,7 +27,7 @@ var config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 var appUUID = os.Getenv("APP_UUID")
 
 var exporterSpec = controller.ExporterSpec{
-	AppNS: os.Getenv("APP_NAMESPACE"),
+	AppNS:       os.Getenv("APP_NAMESPACE"),
 	ChaosEngine: os.Getenv("CHAOSENGINE"),
 }
 
@@ -42,21 +39,14 @@ func TestChaos(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		fmt.Println(err)
-	}
-
 	clientSet, err := clientV1alpha1.NewForConfig(config)
 	if err != nil {
 		fmt.Println(err)
 	}
-
 	By("Creating ChaosEngine")
 	chaosEngine := &chaosEngineV1alpha1.ChaosEngine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "engine-nginx",
-			Namespace: "litmus",
+			Name: "engine-nginx",
 		},
 		Spec: chaosEngineV1alpha1.ChaosEngineSpec{
 			Appinfo: chaosEngineV1alpha1.ApplicationParams{
@@ -74,25 +64,11 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	response, err := clientSet.LitmuschaosV1alpha1().ChaosEngines("litmus").Create(chaosEngine)
-	Expect(err).To(BeNil())
-
-	fmt.Println(response, err)
-
-	By("Building Exporter")
-	cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig="+os.Getenv("HOME")+"/.kube/config")
-	cmd.Stdout = os.Stdout
-	err = cmd.Start()
-
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println("Error while creating ChaosEngine, err: ", err)
 	}
+	fmt.Println("\nDeployed ChaosEngine:", response)
 	Expect(err).To(BeNil())
-
-	// wait for execution of exporter
-	time.Sleep(4000000000)
-
-	fmt.Println("process id", cmd.Process.Pid)
-
 })
 
 var _ = Describe("BDD on chaos-exporter", func() {
@@ -129,52 +105,56 @@ var _ = Describe("BDD on chaos-exporter", func() {
 	})
 
 	// BDD case 2
-	Context("Curl the prometheus metrics--", func() {
+	Context("Curl the prometheus metrics", func() {
 		It("Should return prometheus metrics", func() {
 
-			By("Sending get request to metrics")
+			By("Running Exporter and Sending get request to metrics")
+			cmd := exec.Command("go", "run", "../../cmd/exporter/main.go", "-kubeconfig="+os.Getenv("HOME")+"/.kube/config")
+			if err := cmd.Start(); err != nil {
+				log.Fatalf("Failed to start exporter: %v", err)
+			}
+			Expect(err).To(BeNil())
+			// wait for execution of exporter
+			log.Println("\nSleeping for 60 second and wait for exporter to start")
+			time.Sleep(60 * time.Second)
 			response, err := http.Get("http://127.0.0.1:8080/metrics")
 			Expect(err).To(BeNil())
-
 			if err != nil {
 				fmt.Printf("%s", err)
 				os.Exit(1)
 			} else {
 				defer response.Body.Close()
-				contents, err := ioutil.ReadAll(response.Body)
+				metrics, err := ioutil.ReadAll(response.Body)
 				if err != nil {
 					fmt.Printf("%s", err)
 					os.Exit(1)
 				}
-				fmt.Printf("%s\n", string(contents))
-
+				fmt.Printf("%s\n", string(metrics))
 				var k8sVersion, openEBSVersion string
 				k8sClientSet, err := kubernetes.NewForConfig(config)
 				if err != nil {
 					fmt.Printf("unable to generate kubernetes clientSet %s: ", err)
 				}
-				k8sVersion, _ = version.GetKubernetesVersion(k8sClientSet)            // getting kubernetes version
-				openEBSVersion, _ = version.GetOpenebsVersion(k8sClientSet, "litmus") // getting openEBS Version
+				k8sVersion, _ = version.GetKubernetesVersion(k8sClientSet)             // getting kubernetes version
+				openEBSVersion, _ = version.GetOpenebsVersion(k8sClientSet, "openebs") // getting openEBS Version
 
-				var tmpStr = "{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"}"
+				var tmpStr= "{app_uid=\"" + appUUID + "\",engine_name=\"engine-nginx\",kubernetes_version=\"" + k8sVersion + "\",openebs_version=\"" + openEBSVersion + "\"}"
 
 				By("Should be matched with total_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_experiment_count" + tmpStr + " 2")))
+				Expect(string(metrics)).Should(ContainSubstring("c_engine_experiment_count" + tmpStr + " 2"))
 
 				By("Should be matched with failed_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_failed_experiments" + tmpStr + " 0")))
+				Expect(string(metrics)).Should(ContainSubstring("c_engine_failed_experiments" + tmpStr + " 0"))
 
 				By("Should be matched with passed_experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_engine_passed_experiments" + tmpStr + " 0")))
+				Expect(string(metrics)).Should(ContainSubstring("c_engine_passed_experiments" + tmpStr + " 0"))
 
 				By("Should be matched with container_kill experiment regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_exp_container_kill" + tmpStr + " 0")))
+				Expect(string(metrics)).Should(ContainSubstring("c_exp_container_kill" + tmpStr + " 0"))
 
 				By("Should be matched with pod_kill experiment experiments regx")
-				Expect(string(contents)).Should(ContainSubstring(string("c_exp_pod_kill" + tmpStr + " 0")))
-
+				Expect(string(metrics)).Should(ContainSubstring("c_exp_pod_kill" + tmpStr + " 0"))
 			}
-
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kumar@mayadata.io>

- Refactor the exporter logic
- Create a new `controller` package
- Move the `scrape file` to `controller` package

Chaos Engine:
```
$ kubectl get chaosengine -o yaml
apiVersion: v1
items:
- apiVersion: litmuschaos.io/v1alpha1
  kind: ChaosEngine
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"litmuschaos.io/v1alpha1","kind":"ChaosEngine","metadata":{"annotations":{},"name":"engine-nginx","namespace":"default"},"spec":{"appinfo":{"applabel":"app=nginx","appns":"default"},"chaosServiceAccount":"chaos-operator","experiments":[{"name":"pod-delete","spec":{"components":null}}]}}
    creationTimestamp: "2019-10-05T09:22:25Z"
    generation: 1
    name: engine-nginx
    namespace: default
    resourceVersion: "12328507"
    selfLink: /apis/litmuschaos.io/v1alpha1/namespaces/default/chaosengines/engine-nginx
    uid: a4fabb70-e751-11e9-89a5-0cc47ab587b8
  spec:
    appinfo:
      applabel: app=nginx
      appns: default
    chaosServiceAccount: chaos-operator
    experiments:
    - name: pod-delete
      spec:
        components: null
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""

```
Generated Metrics:
```
# HELP c_engine_experiment_count Total number of experiments executed by the chaos engine
# TYPE c_engine_experiment_count gauge
c_engine_experiment_count{app_uid="6e7f6678-e67f-11e9-89a5-0cc47ab587b8",engine_name="engine-nginx",kubernetes_version="v1.13.10",openebs_version="1.1.0"} 1
# HELP c_engine_failed_experiments Total number of failed experiments
# TYPE c_engine_failed_experiments gauge
c_engine_failed_experiments{app_uid="6e7f6678-e67f-11e9-89a5-0cc47ab587b8",engine_name="engine-nginx",kubernetes_version="v1.13.10",openebs_version="1.1.0"} 1
# HELP c_engine_passed_experiments Total number of passed experiments
# TYPE c_engine_passed_experiments gauge
c_engine_passed_experiments{app_uid="6e7f6678-e67f-11e9-89a5-0cc47ab587b8",engine_name="engine-nginx",kubernetes_version="v1.13.10",openebs_version="1.1.0"} 0
# HELP c_exp_pod_delete 
# TYPE c_exp_pod_delete gauge
c_exp_pod_delete{app_uid="6e7f6678-e67f-11e9-89a5-0cc47ab587b8",engine_name="engine-nginx",kubernetes_version="v1.13.10",openebs_version="1.1.0"} 2
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 1.1409e-05
go_gc_duration_seconds{quantile="0.25"} 1.3208e-05
go_gc_duration_seconds{quantile="0.5"} 8.8436e-05
go_gc_duration_seconds{quantile="0.75"} 0.000170756
go_gc_duration_seconds{quantile="1"} 0.000231374
go_gc_duration_seconds_sum 0.000515183
go_gc_duration_seconds_count 5
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 9
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.13.1"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 8.050048e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.6065624e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.445929e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 82382
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 0.00033504257973191376
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 2.38592e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 8.050048e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.6311808e+07
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.0207232e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 26467
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 5.6311808e+07
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 6.651904e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.5702673832080374e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 108849
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 6944
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 16384
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 83096
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 98304
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.0359728e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 968911
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 589824
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 589824
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 7.2024312e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 10
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.12
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 8
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.05152e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.57026737518e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 7.39971072e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes -1
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 14
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```