### PR TITLE
removed deprecated field in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: xenial
 env:
   global:


### PR DESCRIPTION
Signed-off-by: Nikita Titov <nekit94-12@hotmail.com>

Refer to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.

> In the next phase of the migration, all builds will run on virtual-machine-based infrastructure – regardless of the configuration for `sudo` in the `.travis.yml`.

> Soon we will run all projects on the virtual-machine-based infrastructure, the sudo keyword will be fully deprecated.