### PR TITLE
(fix) ignore application UUID for infra chaos

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -77,7 +77,7 @@ func getExporterSpecs() (controller.ExporterSpec, error) {
 	chaosEngine := os.Getenv("CHAOSENGINE")
 
 	// Validate availability of mandatory ENV
-	if chaosEngine == "" || applicationUUID == "" {
+	if chaosEngine == "" {
 		return controller.ExporterSpec{}, fmt.Errorf("please specify correct APP_UUID & CHAOSENGINE ENVs")
 	}
 


### PR DESCRIPTION
- In case of infra chaos experiments which have the `annotationCheck: false`, the APP_UUIDs are not derived. This causes the exporter to crash
- The APP_UID is an optional metric label which can be used as filter by monitoring clients. The exporter should still continue to work w/o it. 

Signed-off-by: ksatchit <ksatchit@mayadata.io>