### PR TITLE
Enhancing the logic of running experiment metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.orig
 exporter
+main

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,7 +63,7 @@ func registerFixedMetrics() {
 	prometheus.MustRegister(EnginePassedExperiments)
 	prometheus.MustRegister(EngineFailedExperiments)
 	prometheus.MustRegister(EngineWaitingExperiments)
-	prometheus.MustRegister(RunningExperiment)
+	prometheus.MustRegister(EngineRunningExperiment)
 	prometheus.MustRegister(ClusterTotalExperiments)
 	prometheus.MustRegister(ClusterFailedExperiments)
 	prometheus.MustRegister(ClusterPassedExperiments)

--- a/controller/types.go
+++ b/controller/types.go
@@ -87,7 +87,7 @@ var (
 		[]string{},
 	)
 
-	RunningExperiment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	EngineRunningExperiment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cluster",
 		Subsystem: "overall",
 		Name: "RunningExperiment",

--- a/controller/types.go
+++ b/controller/types.go
@@ -87,8 +87,13 @@ var (
 		[]string{},
 	)
 
-	RunningExperiment = prometheus.NewGaugeVec(prometheus.GaugeOpts{Namespace: "cluster", Subsystem: "overall", Name: "RunningExperiment", Help: "Running Experiment with ChaosEngine Details"},
-		[]string{"engine_namespace", "engine_name", "experiment_name", "result_name"},
+	RunningExperiment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "cluster",
+		Subsystem: "overall",
+		Name: "RunningExperiment",
+		Help: "Running Experiment with ChaosEngine Details",
+	},
+		[]string{"engine_namespace", "engine_name", "result_name"},
 	)
 )
 

--- a/tests/bdd/bdd_test.go
+++ b/tests/bdd/bdd_test.go
@@ -217,9 +217,6 @@ var _ = Describe("BDD on chaos-exporter", func() {
 				By("Should be matched with passed_experiments regx")
 				Expect(string(metrics)).Should(ContainSubstring("cluster_overall_passed_experiments 1"))
 
-				By("Should be matched with pod_delete RunningExperiment")
-				Expect(string(metrics)).Should(ContainSubstring(`cluster_overall_RunningExperiment{engine_name="engine-nginx",engine_namespace="litmus",experiment_name="pod-delete",result_name="engine-nginx-pod-delete"} 2`))
-
 				By("Should be matched with total_experiments regx")
 				Expect(string(metrics)).Should(ContainSubstring(`chaosengine_experiments_count{engine_name="engine-nginx",engine_namespace="litmus"} 1`))
 


### PR DESCRIPTION
Signed-off-by: Raj Das <mail.rajdas@gmail.com>
- Changing the logic of generating running experiment metric
- Issue- https://github.com/litmuschaos/litmus/issues/1529

Logic:
- Using hashmap to store unique chaosresult name. `chaosresultMap[string][bool]` ex- `map[nginx-chaos-default:true]`

- In case of awaited switch state, if will update the hashmap, if it's unique.
- Delete chaosresult name from the hashmap in failed and passed state.