### PR TITLE
chore(verdict): Adding chaosresult_verdict metrics

### DIFF
--- a/controller/collect-data.go
+++ b/controller/collect-data.go
@@ -1,0 +1,237 @@
+package controller
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/litmuschaos/chaos-exporter/pkg/clients"
+	"github.com/litmuschaos/chaos-exporter/pkg/log"
+	litmuschaosv1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// GetResultList return the result list correspond to the monitoring enabled chaosengine
+func GetResultList(clients clients.ClientSets, chaosNamespace string, monitoringEnabled *MonitoringEnabled) (litmuschaosv1alpha1.ChaosResultList, error) {
+
+	chaosResultList, err := clients.LitmusClient.ChaosResults(chaosNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return litmuschaosv1alpha1.ChaosResultList{}, err
+	}
+	// waiting until any chaosresult found
+	if len(chaosResultList.Items) == 0 {
+		if monitoringEnabled.IsChaosResultsAvailable {
+			monitoringEnabled.IsChaosResultsAvailable = false
+			log.Warnf("No chaosresult found!")
+			log.Info("[Wait]: Waiting for the chaosresult ... ")
+		}
+		return litmuschaosv1alpha1.ChaosResultList{}, nil
+	}
+
+	if !monitoringEnabled.IsChaosResultsAvailable {
+		log.Info("[Wait]: Cheers! Wait is over, found desired chaosresult")
+		monitoringEnabled.IsChaosResultsAvailable = true
+	}
+
+	return *chaosResultList, nil
+}
+
+// getExperimentMetricsFromResult derive all the metrics data from the chaosresult and set into resultDetails struct
+func (resultDetails *ChaosResultDetails) getExperimentMetricsFromResult(chaosResult *litmuschaosv1alpha1.ChaosResult, clients clients.ClientSets) error {
+	verdict := strings.ToLower(chaosResult.Status.ExperimentStatus.Verdict)
+	probeSuccesPercentage, err := getProbeSuccessPercentage(chaosResult)
+	if err != nil {
+		return err
+	}
+
+	engine, err := clients.LitmusClient.ChaosEngines(chaosResult.Namespace).Get(chaosResult.Spec.EngineName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// deriving all the events present inside specific chaosengine
+	events, err := getEventsForSpecificInvolvedResource(clients, engine.UID, chaosResult.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// setting all the values inside resultdetails struct
+	resultDetails.setName(chaosResult.Name).
+		setUID(chaosResult.UID).
+		setNamespace(chaosResult.Namespace).
+		setProbeSuccesPercentage(probeSuccesPercentage).
+		setVerdict(chaosResult.Status.ExperimentStatus.Verdict).
+		setStartTime(events).
+		setEndTime(events).
+		setChaosInjectTime(events).
+		setChaosEngineName(chaosResult.Spec.EngineName).
+		setChaosEngineLabel(engine.Labels[EngineLabelKey]).
+		setAppLabel(engine.Spec.Appinfo.Applabel).
+		setAppNs(engine.Spec.Appinfo.Appns).
+		setAppKind(engine.Spec.Appinfo.AppKind).
+		setTotalDuration().
+		setVerdictCount(verdict, chaosResult).
+		setResultData()
+
+	return nil
+}
+
+// initialiseResult create the new instance of the ChaosResultDetails struct
+func initialiseResult() *ChaosResultDetails {
+	return &ChaosResultDetails{}
+
+}
+
+// setName sets name inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setName(name string) *ChaosResultDetails {
+	resultDetails.Name = name
+	return resultDetails
+}
+
+// setNamespace sets namespace inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setNamespace(namespace string) *ChaosResultDetails {
+	resultDetails.Namespace = namespace
+	return resultDetails
+}
+
+// setUID sets result uid inside the resultDetails struct
+func (resultDetails *ChaosResultDetails) setUID(uid clientTypes.UID) *ChaosResultDetails {
+	resultDetails.UID = uid
+	return resultDetails
+}
+
+// setVerdict sets result verdict inside the resultDetails struct
+func (resultDetails *ChaosResultDetails) setVerdict(verdict string) *ChaosResultDetails {
+	resultDetails.Verdict = verdict
+	return resultDetails
+}
+
+// setVerdict increase the metric count based on given verdict/events
+func (resultDetails *ChaosResultDetails) setVerdictCount(verdict string, chaosResult *litmuschaosv1alpha1.ChaosResult) *ChaosResultDetails {
+
+	// count the chaosresult as awaited if verdict is awaited
+	switch verdict {
+	case "awaited":
+		resultDetails.AwaitedExperiments++
+	}
+	resultDetails.PassedExperiments = float64(chaosResult.Status.History.PassedRuns)
+	resultDetails.FailedExperiments = float64(chaosResult.Status.History.FailedRuns)
+	return resultDetails
+}
+
+// setProbeSuccesPercentage sets ProbeSuccesPercentage inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setProbeSuccesPercentage(probeSuccesPercentage float64) *ChaosResultDetails {
+	resultDetails.ProbeSuccesPercentage = probeSuccesPercentage
+	return resultDetails
+}
+
+// setChaosEngineName sets the chaosEngine name inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setChaosEngineName(chaosEngineName string) *ChaosResultDetails {
+	resultDetails.ChaosEngineName = chaosEngineName
+	return resultDetails
+}
+
+// setAppLabel sets the target application labels inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setAppLabel(appLabel string) *ChaosResultDetails {
+	resultDetails.AppLabel = appLabel
+	return resultDetails
+}
+
+// setAppLabel sets the target application namespace inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setAppNs(appNs string) *ChaosResultDetails {
+	resultDetails.AppNs = appNs
+	return resultDetails
+}
+
+// setAppLabel sets the target application kind inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setAppKind(appKind string) *ChaosResultDetails {
+	resultDetails.AppKind = appKind
+	return resultDetails
+}
+
+// setChaosEngineLabel sets the chaosEngine label inside resultDetails struct
+func (resultDetails *ChaosResultDetails) setChaosEngineLabel(engineLabel string) *ChaosResultDetails {
+	resultDetails.ChaosEngineLabel = engineLabel
+	return resultDetails
+}
+
+// setStartTime sets start time of experiment run
+func (resultDetails *ChaosResultDetails) setStartTime(events corev1.EventList) *ChaosResultDetails {
+	startTime := int64(0)
+	for _, event := range events.Items {
+		// job create event by runner
+		if event.Reason == "ExperimentDependencyCheck" {
+			startTime = maximum(startTime, event.LastTimestamp.Unix())
+		}
+	}
+	resultDetails.StartTime = float64(startTime)
+	return resultDetails
+}
+
+// setEndTime sets end time of the experiment run
+func (resultDetails *ChaosResultDetails) setEndTime(events corev1.EventList) *ChaosResultDetails {
+	endTime := int64(0)
+	for _, event := range events.Items {
+		if event.Reason == "Summary" {
+			endTime = maximum(endTime, event.LastTimestamp.Unix())
+		}
+	}
+	resultDetails.EndTime = float64(endTime)
+	return resultDetails
+}
+
+// setChaosInjectTime sets the chaos injection time
+func (resultDetails *ChaosResultDetails) setChaosInjectTime(events corev1.EventList) *ChaosResultDetails {
+	chaosInjectTime := int64(0)
+	for _, event := range events.Items {
+		if event.Reason == "ChaosInject" {
+			chaosInjectTime = maximum(chaosInjectTime, event.LastTimestamp.Unix())
+		}
+	}
+	resultDetails.InjectionTime = float64(chaosInjectTime)
+	return resultDetails
+}
+
+// setTotalDuration sets total chaos duration for the experiment run
+func (resultDetails *ChaosResultDetails) setTotalDuration() *ChaosResultDetails {
+	resultDetails.TotalDuration = math.Max(0, resultDetails.EndTime-resultDetails.StartTime)
+	return resultDetails
+}
+
+// getProbeSuccessPercentage derive the probeSucessPercentage from the chaosresult
+func getProbeSuccessPercentage(chaosResult *litmuschaosv1alpha1.ChaosResult) (float64, error) {
+	probeSuccesPercentage := float64(0)
+	if chaosResult.Status.ExperimentStatus.ProbeSuccessPercentage != "Awaited" && chaosResult.Status.ExperimentStatus.ProbeSuccessPercentage != "" {
+		probeSuccesPercentage, err = strconv.ParseFloat(chaosResult.Status.ExperimentStatus.ProbeSuccessPercentage, 64)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return probeSuccesPercentage, nil
+}
+
+// getEventsForSpecificInvolvedResource derive all the events correspond to the specific resource
+func getEventsForSpecificInvolvedResource(clients clients.ClientSets, resourceUID clientTypes.UID, chaosNamespace string) (corev1.EventList, error) {
+	finalEventList := corev1.EventList{}
+	eventsList, err := clients.KubeClient.CoreV1().Events(chaosNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return corev1.EventList{}, err
+	}
+
+	for _, event := range eventsList.Items {
+		if event.InvolvedObject.UID == resourceUID {
+			finalEventList.Items = append(finalEventList.Items, event)
+		}
+	}
+	return finalEventList, nil
+}
+
+// Maximum returns the maximum value
+func maximum(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -56,6 +56,7 @@ func (gaugeMetrics *GaugeMetrics) RegisterFixedMetrics() {
 	prometheus.MustRegister(gaugeMetrics.ResultFailedExperiments)
 	prometheus.MustRegister(gaugeMetrics.ResultAwaitedExperiments)
 	prometheus.MustRegister(gaugeMetrics.ResultProbeSuccessPercentage)
+	prometheus.MustRegister(gaugeMetrics.ResultVerdict)
 	prometheus.MustRegister(gaugeMetrics.ExperimentStartTime)
 	prometheus.MustRegister(gaugeMetrics.ExperimentEndTime)
 	prometheus.MustRegister(gaugeMetrics.ExperimentChaosInjectedTime)

--- a/controller/handle-result-deletion.go
+++ b/controller/handle-result-deletion.go
@@ -1,0 +1,152 @@
+package controller
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	litmuschaosv1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+)
+
+// unsetDeletedChaosResults unset the metrics correspond to deleted chaosresults
+func (gaugeMetrics *GaugeMetrics) unsetDeletedChaosResults(oldChaosResults, newChaosResults *litmuschaosv1alpha1.ChaosResultList) {
+	for _, oldResult := range oldChaosResults.Items {
+		found := false
+		for _, newResult := range newChaosResults.Items {
+			if oldResult.UID == newResult.UID {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			for _, value := range resultStore[string(oldResult.UID)] {
+
+				probeSuccesPercentage, _ := getProbeSuccessPercentage(&oldResult)
+				resultDetails := initialiseResult().
+					setName(oldResult.Name).
+					setNamespace(oldResult.Namespace).
+					setProbeSuccesPercentage(probeSuccesPercentage).
+					setVerdict(value.Verdict).
+					setAppLabel(value.AppLabel).
+					setAppNs(value.AppNs).
+					setAppKind(value.AppKind).
+					setChaosEngineName(oldResult.Spec.EngineName).
+					setChaosEngineLabel(value.Label)
+
+				gaugeMetrics.unsetResultChaosMetrics(resultDetails)
+			}
+			// delete the corresponding entry from the map
+			delete(resultStore, string(oldResult.UID))
+		}
+	}
+}
+
+// unsetVerdictMetrics unset the metrics when chaosresult verdict changes
+// if same chaosresult is continuously repeated more than scrape interval then it sets the metrics value to 0
+func (gaugeMetrics *GaugeMetrics) unsetVerdictMetrics(resultDetails ChaosResultDetails) float64 {
+	scrapeTime, _ := strconv.Atoi(getEnv("TSDB_SCRAPE_INTERVAL", "10"))
+	result, ok := matchVerdict[string(resultDetails.UID)]
+	if ok {
+		// if verdict is different then delete the older metrics having outdated verdict
+		if result.Verdict != resultDetails.Verdict {
+			gaugeMetrics.ResultVerdict.DeleteLabelValues(resultDetails.Namespace, resultDetails.Name, resultDetails.ChaosEngineName, resultDetails.ChaosEngineLabel, result.Verdict,
+				fmt.Sprintf("%f", result.ProbeSuccessPercentage), resultDetails.AppLabel, resultDetails.AppNs, resultDetails.AppKind)
+
+			// update the values inside matchVerdict
+			matchVerdict[string(resultDetails.UID)] = result.setCount(1).
+				setVerdict(resultDetails.Verdict).
+				setProbeSuccesPercentage(resultDetails.ProbeSuccesPercentage)
+			return float64(1)
+		} else {
+			result.Count++
+			matchVerdict[string(resultDetails.UID)] = result
+			if result.Count >= scrapeTime {
+				return float64(0)
+			}
+			return float64(1)
+		}
+	}
+
+	// update the values inside matchVerdict
+	matchVerdict[string(resultDetails.UID)] = initialiseResultData().
+		setCount(1).
+		setVerdict(resultDetails.Verdict).
+		setProbeSuccesPercentage(resultDetails.ProbeSuccesPercentage)
+	return float64(0)
+}
+
+// getEnv derived the ENVs and sets the default value if env contains empty value
+func getEnv(key, defaultValue string) string {
+	scrapeTime := os.Getenv(key)
+	if scrapeTime == "" {
+		scrapeTime = defaultValue
+	}
+	return scrapeTime
+}
+
+// setResultData sets the result data into resultStore so that the data
+//can be used while handling chaosresult deletion
+func (resultDetails *ChaosResultDetails) setResultData() {
+	resultData := initialiseResultData().
+		setLabel(resultDetails.ChaosEngineLabel).
+		setAppKind(resultDetails.AppKind).
+		setNs(resultDetails.AppNs).
+		setAppLabel(resultDetails.AppLabel).
+		setVerdict(resultDetails.Verdict).
+		setCount(0).
+		setProbeSuccesPercentage(resultDetails.ProbeSuccesPercentage)
+
+	if resultStore[string(resultDetails.UID)] != nil {
+		resultStore[string(resultDetails.UID)] = append(resultStore[string(resultDetails.UID)], *resultData)
+	} else {
+		resultStore[string(resultDetails.UID)] = []ResultData{*resultData}
+	}
+}
+
+// initialiseResultData creates the instance of ResultData struct
+func initialiseResultData() *ResultData {
+	return &ResultData{}
+}
+
+// setLabel sets the label inside resultData struct
+func (resultData *ResultData) setLabel(label string) *ResultData {
+	resultData.Label = label
+	return resultData
+}
+
+// setAppKind sets the appkind inside resultData struct
+func (resultData *ResultData) setAppKind(appKind string) *ResultData {
+	resultData.AppKind = appKind
+	return resultData
+}
+
+// setNs sets the appNs inside resultData struct
+func (resultData *ResultData) setNs(appNs string) *ResultData {
+	resultData.AppNs = appNs
+	return resultData
+}
+
+// setAppLabel sets the appLabel inside resultData struct
+func (resultData *ResultData) setAppLabel(appLabel string) *ResultData {
+	resultData.AppLabel = appLabel
+	return resultData
+}
+
+// setVerdict sets the verdict inside resultData struct
+func (resultData *ResultData) setVerdict(verdict string) *ResultData {
+	resultData.Verdict = verdict
+	return resultData
+}
+
+// setCount sets the count inside resultData struct
+func (resultData *ResultData) setCount(count int) *ResultData {
+	resultData.Count = count
+	return resultData
+}
+
+// setProbeSuccesPercentage sets the probeSuccessPercentage inside resultData struct
+func (resultData *ResultData) setProbeSuccesPercentage(probeSuccessPercentage float64) *ResultData {
+	resultData.ProbeSuccessPercentage = float64(probeSuccessPercentage)
+	return resultData
+}

--- a/deploy/chaos-exporter.yaml
+++ b/deploy/chaos-exporter.yaml
@@ -22,6 +22,8 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ''
+        - name: TSDB_SCRAPE_INTERVAL
+          value: ''
       serviceAccountName: litmus
 ---
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- Generating chaosresult_experiment_verdict metrics to have the `chaosresult_verdict=$currentverdict` label filter and value as 1.
- Metrics will be similar to : 
```
# HELP litmuschaos_experiment_verdict Verdict of the experiments
# TYPE litmuschaos_experiment_verdict gauge
litmuschaos_experiment_verdict{chaosengine_context="test",chaosengine_name="helloservice-pod-delete",chaosresult_name="helloservice-pod-delete-pod-delete",chaosresult_namespace="shubham",chaosresult_verdict="Pass"} 1
```