### PR TITLE
Add option to change default container registry during image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 
 # docker info
+DOCKER_REGISTRY ?= docker.io
 DOCKER_REPO ?= litmuschaos
 DOCKER_IMAGE ?= chaos-exporter
 DOCKER_TAG ?= ci
@@ -58,10 +59,10 @@ test:
 .PHONY: build-chaos-exporter build-chaos-exporter-amd64 push-chaos-exporter
 
 build-chaos-exporter:
-	@docker buildx build --file Dockerfile --progress plane  --no-cache --platform linux/arm64,linux/amd64 --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	@docker buildx build --file Dockerfile --progress plane  --no-cache --platform linux/arm64,linux/amd64 --tag $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 build-for-amd64:
-	@docker build -f Dockerfile  --no-cache -t $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .  --build-arg TARGETPLATFORM="linux/amd64"
+	@docker build -f Dockerfile  --no-cache -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .  --build-arg TARGETPLATFORM="linux/amd64"
 
 push-chaos-exporter:
-	@docker buildx build --file Dockerfile --progress plane --no-cache --push --platform linux/arm64,linux/amd64 --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	@docker buildx build --file Dockerfile --progress plane --no-cache --push --platform linux/arm64,linux/amd64 --tag $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

**What this PR does / why we need it:**

This PR introduces an option to specify a container registry where litmus images will be pushed after the build. The registry is specified by env variable DOCKER_REGISTRY.