### PR TITLE
Add VerdictReset variable to ResultData struct to fix verdict metrics never reseting to 0 #120

### DIFF
--- a/controller/collect-data.go
+++ b/controller/collect-data.go
@@ -87,9 +87,10 @@ func (resultDetails *ChaosResultDetails) getExperimentMetricsFromResult(chaosRes
 
 	// it won't export/override the metrics if chaosengine is in completed state and
 	// experiment's final verdict[passed,failed,stopped] is already exported/overridden
+	// and 'litmuschaos_experiment_verdict' metric was reset to 0
 	if engine.Status.EngineStatus == v1alpha1.EngineStatusCompleted {
 		result, ok := matchVerdict[string(resultDetails.UID)]
-		if !ok || (ok && result.Verdict == resultDetails.Verdict) {
+		if !ok || (ok && result.Verdict == resultDetails.Verdict && result.VerdictReset) {
 			return true, nil
 		}
 	}

--- a/controller/handle-result-deletion.go
+++ b/controller/handle-result-deletion.go
@@ -70,12 +70,14 @@ func (gaugeMetrics *GaugeMetrics) unsetOutdatedMetrics(resultDetails ChaosResult
 		}
 	default:
 		result = initialiseResultData().
-			setCount(1)
+			setCount(1).
+			setVerdictReset(false)
 	}
 
 	// update the values inside matchVerdict
 	matchVerdict[string(resultDetails.UID)] = result.setVerdict(resultDetails.Verdict).
-		setProbeSuccesPercentage(resultDetails.ProbeSuccessPercentage)
+		setProbeSuccesPercentage(resultDetails.ProbeSuccessPercentage).
+		setVerdictReset(reset)
 
 	if reset {
 		return float64(0)
@@ -104,6 +106,7 @@ func (resultDetails *ChaosResultDetails) setResultData() {
 		setVerdict(resultDetails.Verdict).
 		setFaultName(resultDetails.FaultName).
 		setCount(0).
+		setVerdictReset(false).
 		setProbeSuccesPercentage(resultDetails.ProbeSuccessPercentage)
 
 	if resultStore[string(resultDetails.UID)] != nil {
@@ -163,6 +166,12 @@ func (resultData *ResultData) setFaultName(fault string) *ResultData {
 // setCount sets the count inside resultData struct
 func (resultData *ResultData) setCount(count int) *ResultData {
 	resultData.Count = count
+	return resultData
+}
+
+// setVerdictReset sets the VerdictReset inside resultData struct
+func (resultData *ResultData) setVerdictReset(verdictreset bool) *ResultData {
+	resultData.VerdictReset = verdictreset
 	return resultData
 }
 

--- a/controller/types.go
+++ b/controller/types.go
@@ -39,6 +39,7 @@ type ResultData struct {
 	AppLabel               string
 	Verdict                string
 	Count                  int
+	VerdictReset           bool
 	ProbeSuccessPercentage float64
 	FaultName              string
 }


### PR DESCRIPTION
- types.go: Added the VerdictReset to ResultData struct
- collect-data.go: Add condition so chaosresult is skipped when the chaosengine is completed and the verdict was reseted
- handle-result-deletion: - Add setter for VerdictReset - Added setter during initialization of resultDetails - Set the verdictReset value to reset variable in unsetOutdatedMetrics

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #120

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #120
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests