### PR TITLE
UBI migration of Images - chaos-exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,18 @@ RUN go env
 RUN CGO_ENABLED=0 go build -buildvcs=false -o /output/chaos-exporter -v ./cmd/exporter/
 
 # Packaging stage
-# Image source: https://github.com/litmuschaos/test-tools/blob/master/custom/hardened-alpine/infra/Dockerfile
-# The base image is non-root (have litmus user) with default litmus directory.
-FROM litmuschaos/infra-alpine
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 LABEL maintainer="LitmusChaos"
 
-COPY --from=builder /output/chaos-exporter /litmus
+ENV APP_DIR="/litmus"
+
+COPY --from=builder /output/chaos-exporter $APP_DIR/
+RUN chown 65534:0 $APP_DIR/chaos-exporter && chmod 755 $APP_DIR/chaos-exporter
+
+WORKDIR $APP_DIR
+USER 65534
+
 CMD ["./chaos-exporter"]
+
 EXPOSE 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Migrate the base images of the chaos-exporter container images of LitmusChaos from infra-alpine to ubi minimal.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4634  (https://github.com/litmuschaos/litmus/issues/4634)

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #4634
-   [ ] Labelled this PR & related issue with `documentation` tag
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests